### PR TITLE
Allow display and summing of zero-amount cells

### DIFF
--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -1137,7 +1137,9 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                                                                 splitVal))))
                                           (if typefilter
                                               (if (eq? typefilter splitAccType)
-                                                  (set! sum (myadd sum splitVal))))
+                                                  (set! sum (if sum 
+                                                                (myadd sum splitVal)
+                                                                splitVal))))
                                           ))
                                       splits-in-transaction)
                             sum)))                                 

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -223,7 +223,7 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
     (define (retrieve-commodity list-of-monetary commodity)
       (if (null? list-of-monetary)
           #f
-          (if (eq? (gnc:gnc-monetary-commodity (car list-of-monetary)) commodity)
+          (if (gnc-commodity-equiv (gnc:gnc-monetary-commodity (car list-of-monetary)) commodity)
               (car list-of-monetary)
               (retrieve-commodity (cdr list-of-monetary) commodity))))
     
@@ -1251,9 +1251,6 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                  current table used-columns def:alternate-row-style
                  account-types-to-reverse))
 
-
-            ;(gnc:warn "(car TC) = " ((cadddr total-collectors) 'format gnc:make-gnc-monetary #f))
-            
             (map (lambda (collector value)
                    (if value
                        (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
@@ -1272,27 +1269,19 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                  total-collectors
                  split-values)
 
-            (gnc:warn "")
-            (gnc:warn "sv = " split-values)
-            (gnc:warn "primary-subtotal-pred = " primary-subtotal-pred)
-            (gnc:warn "next = " next)
-            (gnc:warn "runner = " (if next (primary-subtotal-pred current next) #f))
-
             (if (and primary-subtotal-pred
                      (or (not next)
                          (and next
                               (not (primary-subtotal-pred current next)))))
                 (begin 
                   (if secondary-subtotal-pred
-
-                      (begin
-                        (secondary-subtotal-renderer
-                         table width current
-                         secondary-subtotal-collectors
-                         def:secondary-subtotal-style used-columns export?)
-                        (for-each (lambda (coll) (coll 'reset #f #f))
-                                  secondary-subtotal-collectors)
-                        ))
+                      
+                      (secondary-subtotal-renderer
+                       table width current
+                       secondary-subtotal-collectors
+                       def:secondary-subtotal-style used-columns export?)
+                      (for-each (lambda (coll) (coll 'reset #f #f))
+                                secondary-subtotal-collectors))
 
                   (primary-subtotal-renderer table width current
                                              primary-subtotal-collectors
@@ -1306,12 +1295,12 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                       (begin 
                         (primary-subheading-renderer
                          next table width def:primary-subtotal-style used-columns)
-
                         (if secondary-subtotal-pred
-                            (secondary-subheading-renderer
-                             next 
-                             table 
-                             width def:secondary-subtotal-style used-columns)))))
+                            (begin
+                              (secondary-subheading-renderer
+                               next 
+                               table 
+                               width def:secondary-subtotal-style used-columns))))))
 
                 (if (and secondary-subtotal-pred
                          (or (not next)

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -219,24 +219,23 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
   (let* ((row-contents '())
          (columns (map (lambda (coll) (coll 'format gnc:make-gnc-monetary #f)) subtotal-collectors))
          (list-of-commodities (delete-duplicates (map gnc:gnc-monetary-commodity (apply append columns)))))
-
+    
     (define (retrieve-commodity list-of-monetary commodity)
       (if (null? list-of-monetary)
           #f
           (if (eq? (gnc:gnc-monetary-commodity (car list-of-monetary)) commodity)
               (car list-of-monetary)
               (retrieve-commodity (cdr list-of-monetary) commodity))))
-    
+
     ;first row
     (addto! row-contents (gnc:make-html-table-cell/size/markup  1 width "total-label-cell" subtotal-string))
     (for-each (lambda (column)
-                (let ((first-monetary #f))
-                  (addto! row-contents
-                          (gnc:make-html-table-cell/markup
-                           "total-number-cell"
-                           (if (pair? column)
-                               (retrieve-commodity column (car list-of-commodities))
-                               (gnc:html-make-empty-cell))))))
+                (addto! row-contents
+                        (gnc:make-html-table-cell/markup
+                         "total-number-cell"
+                         (if (pair? column)
+                             (retrieve-commodity column (car list-of-commodities))
+                             (gnc:html-make-empty-cell)))))
               columns)
     (gnc:html-table-append-row/markup! table subtotal-style (reverse row-contents))
 
@@ -1263,7 +1262,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                  current table used-columns def:alternate-row-style
                  account-types-to-reverse))
 
-            ;(gnc:warn "sv = " split-values)
+
             ;(gnc:warn "(car TC) = " ((cadddr total-collectors) 'format gnc:make-gnc-monetary #f))
             
             (map (lambda (collector value)
@@ -1283,7 +1282,13 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                        (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
                  total-collectors
                  split-values)
-            
+
+            (gnc:warn "")
+            (gnc:warn "sv = " split-values)
+            (gnc:warn "primary-subtotal-pred = " primary-subtotal-pred)
+            (gnc:warn "next = " next)
+            (gnc:warn "runner = " (if next (primary-subtotal-pred current next) #f))
+
             (if (and primary-subtotal-pred
                      (or (not next)
                          (and next

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -604,14 +604,12 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
                              (gnc:html-transaction-anchor
                               parent
                               (gnc:make-gnc-monetary report-currency cell))))
-                    (addto! row-contents (gnc:html-make-empty-cell))          
-                              ))
+                    (addto! row-contents (gnc:html-make-empty-cell))))
               cells)
     
     (gnc:html-table-append-row/markup! table row-style
                                        (reverse row-contents))
-    cells
-    ))
+    cells))
 
 (define date-sorting-types (list 'date 'register-order))
 
@@ -648,8 +646,7 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
                  gnc:*transaction-report-options*
                  gnc:pagename-general
                  optname-currency
-                 x))
-    ))
+                 x))))
 
   (gnc:options-add-currency!
    gnc:*transaction-report-options* gnc:pagename-general optname-currency "f")
@@ -675,8 +672,7 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
     (lambda ()
       '())
     #f #t
-    (list ACCT-TYPE-INCOME ACCT-TYPE-EXPENSE ACCT-TYPE-PAYABLE ACCT-TYPE-RECEIVABLE)
-    ))
+    (list ACCT-TYPE-INCOME ACCT-TYPE-EXPENSE ACCT-TYPE-PAYABLE ACCT-TYPE-RECEIVABLE)))
 
   (gnc:register-trep-option
    (gnc:make-string-option
@@ -696,8 +692,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
     (lambda ()
       '())
     #f #t
-    (list ACCT-TYPE-ASSET ACCT-TYPE-LIABILITY)
-    ))
+    (list ACCT-TYPE-ASSET ACCT-TYPE-LIABILITY)))
 
   
   (gnc:register-trep-option
@@ -1131,8 +1126,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
            (total-purchases (lambda (s) (myadd (tax-on-purchases s) (purchases-without-tax s))))
            (bank-remittance (lambda (s) (myneg (myadd (total-sales s) (total-purchases s)))))
            (net-income (lambda (s) (myneg (myadd (sales-without-tax s) (purchases-without-tax s)))))
-           (tax-payable (lambda (s) (myneg (myadd (tax-on-purchases s) (tax-on-sales s)))))
-           )
+           (tax-payable (lambda (s) (myneg (myadd (tax-on-purchases s) (tax-on-sales s))))))
         (append
          (list (cons "Total Sales" total-sales))
          (if (gnc:option-value (gnc:lookup-option options gnc:pagename-display (N_ "Individual income columns")))
@@ -1244,8 +1238,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                                 options
                                 current-row-style
                                 account-types-to-reverse
-                                #t))
-                 )
+                                #t)))
             (if multi-rows?
                 (add-other-split-rows
                  current table used-columns def:alternate-row-style
@@ -1574,8 +1567,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
          (secondary-order (opt-val pagename-sorting "Secondary Sort Order"))
          (void-status (opt-val gnc:pagename-accounts optname-void-transactions))
          (splits '())
-         (query (qof-query-create-for-splits)) 
-         )
+         (query (qof-query-create-for-splits)))
 
     ;(gnc:warn "c1 is " c_account_1)
     ;(gnc:warn "c2 is " c_account_2)
@@ -1630,7 +1622,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                                      splits))))
 
           ; We have to remove duplicates because the report will *sum* amounts in a transaction
-	  ; otherwise it will double count where transaction contains 2 splits in same account
+          ; otherwise it will double count where transaction contains 2 splits in same account
           (set! splits (splits-filter-unique-transactions splits))
           
           (if (not (null? splits))
@@ -1690,8 +1682,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                       (gnc:html-markup-p 
                        "There are no input/output tax accounts set up. This is probably not what"
                        " you want. "
-                       TAX-SETUP-DESC
-                       ))))
+                       TAX-SETUP-DESC))))
                 
                 (gnc:html-document-add-object!
                  document 

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -672,7 +672,7 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
     (lambda ()
       '())
     #f #t
-    (list ACCT-TYPE-INCOME ACCT-TYPE-EXPENSE ACCT-TYPE-PAYABLE ACCT-TYPE-RECEIVABLE)))
+    (list ACCT-TYPE-INCOME ACCT-TYPE-EXPENSE)))
 
   (gnc:register-trep-option
    (gnc:make-string-option

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -226,31 +226,25 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
           (if (eq? (gnc:gnc-monetary-commodity (car list-of-monetary)) commodity)
               (car list-of-monetary)
               (retrieve-commodity (cdr list-of-monetary) commodity))))
-
+    
+    (define (add-columns commodity)
+      (for-each (lambda (column)
+                  (addto! row-contents
+                          (gnc:make-html-table-cell/markup
+                           "total-number-cell"
+                           (retrieve-commodity column commodity))))
+                columns))
+      
     ;first row
     (addto! row-contents (gnc:make-html-table-cell/size/markup  1 width "total-label-cell" subtotal-string))
-    (for-each (lambda (column)
-                (addto! row-contents
-                        (gnc:make-html-table-cell/markup
-                         "total-number-cell"
-                         (if (pair? column)
-                             (retrieve-commodity column (car list-of-commodities))
-                             (gnc:html-make-empty-cell)))))
-              columns)
+    (add-columns (car list-of-commodities))
     (gnc:html-table-append-row/markup! table subtotal-style (reverse row-contents))
 
     ;subsequent rows
     (for-each (lambda (commodity)
                 (set! row-contents '())
                 (addto! row-contents (gnc:make-html-table-cell/size/markup 1 width "total-label-cell" ""))
-                (for-each (lambda (column)
-                            (addto! row-contents
-                                    (gnc:make-html-table-cell/markup
-                                     "total-number-cell"
-                                     (if (pair? column)
-                                         (retrieve-commodity column commodity)
-                                         (gnc:html-make-empty-cell)))))
-                          columns)
+                (add-columns commodity)
                 (gnc:html-table-append-row/markup! table subtotal-style (reverse row-contents)))
               (cdr list-of-commodities))))
 
@@ -1120,15 +1114,10 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                                                (splitAccName (xaccAccountGetName splitAcc)))
                                           (if accountlist
                                               (if (member splitAcc accountlist)
-                                                  (set! sum (if sum 
-                                                                (myadd sum splitVal)
-                                                                splitVal))))
+                                                  (set! sum (myadd sum splitVal))))
                                           (if typefilter
                                               (if (eq? typefilter splitAccType)
-                                                  (set! sum (if sum 
-                                                                (myadd sum splitVal)
-                                                                splitVal))))
-                                          ))
+                                                  (set! sum (myadd sum splitVal))))))
                                       splits-in-transaction)
                             sum)))                                 
            ;(sales-without-tax (lambda (s) (split-adder s #f ACCT-TYPE-INCOME)))

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -223,7 +223,7 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
     (define (retrieve-commodity list-of-monetary commodity)
       (if (null? list-of-monetary)
           #f
-          (if (gnc-commodity-equiv (gnc:gnc-monetary-commodity (car list-of-monetary)) commodity)
+          (if (gnc-commodity-equal (gnc:gnc-monetary-commodity (car list-of-monetary)) commodity)
               (car list-of-monetary)
               (retrieve-commodity (cdr list-of-monetary) commodity))))
     

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -1267,8 +1267,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                          (and next
                               (not (primary-subtotal-pred current next)))))
                 (begin 
-                  (if secondary-subtotal-pred
-                      
+                  (if secondary-subtotal-pred                      
                       (secondary-subtotal-renderer
                        table width current
                        secondary-subtotal-collectors


### PR DESCRIPTION
Allows display of $0.00 cells which may be useful for zero-GST jurisdictions.
Also disallow AP/AR accounts from account selection; this provides no benefit to this report.