### PR TITLE
Overhaul Sorting tab

### DIFF
--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -51,6 +51,8 @@
 (define optname-prime-sortkey (N_ "Primary Key"))
 (define optname-prime-subtotal (N_ "Primary Subtotal"))
 (define optname-prime-date-subtotal (N_ "Primary Subtotal for Date Key"))
+(define optname-full-account-name (N_ "Show Full Account Name"))
+(define optname-show-account-code (N_ "Show Account Code"))
 (define optname-sec-sortkey (N_ "Secondary Key"))
 (define optname-sec-subtotal (N_ "Secondary Subtotal"))
 (define optname-sec-date-subtotal (N_ "Secondary Subtotal for Date Key"))
@@ -628,6 +630,8 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
   (define gnc:*transaction-report-options* (gnc:new-options))
   (define (gnc:register-trep-option new-option)
     (gnc:register-option gnc:*transaction-report-options* new-option))
+  (define prime-sortkey-subtotal-enabled #t)
+  (define sec-sortkey-subtotal-enabled #f)
   
   ;; General options
   
@@ -888,23 +892,34 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
       'account-name
       key-choice-list #f
       (lambda (x)
-        (gnc-option-db-set-option-selectable-by-name
-         options pagename-sorting optname-prime-subtotal
-         (and (member x subtotal-enabled) #t))
+        (set! prime-sortkey-subtotal-enabled (member x subtotal-enabled))
+
         (gnc-option-db-set-option-selectable-by-name
          options pagename-sorting optname-prime-date-subtotal
-         (if (member x date-sorting-types) #t #f)))))
+         (if (member x date-sorting-types) #t #f))
+        
+        (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-prime-subtotal
+         (or prime-sortkey-subtotal-enabled sec-sortkey-subtotal-enabled))
+        
+        (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-full-account-name
+         (or prime-sortkey-subtotal-enabled sec-sortkey-subtotal-enabled))
+         
+        (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-show-account-code
+         (or prime-sortkey-subtotal-enabled sec-sortkey-subtotal-enabled)))))
     
     (gnc:register-trep-option
      (gnc:make-simple-boolean-option
-      pagename-sorting (N_ "Show Full Account Name")
+      pagename-sorting optname-full-account-name
       "a1" 
       (N_ "Show the full account name for subtotals and subtitles?")
       #f))
     
     (gnc:register-trep-option
      (gnc:make-simple-boolean-option
-      pagename-sorting (N_ "Show Account Code")
+      pagename-sorting optname-show-account-code
       "a2" 
       (N_ "Show the account code for subtotals and subtitles?")
       #f))
@@ -939,12 +954,23 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
       'date
       key-choice-list #f
       (lambda (x)
-        (gnc-option-db-set-option-selectable-by-name
-         options pagename-sorting optname-sec-subtotal
-         (and (member x subtotal-enabled) #t))
+        (set! sec-sortkey-subtotal-enabled (member x subtotal-enabled))
+        
         (gnc-option-db-set-option-selectable-by-name
          options pagename-sorting optname-sec-date-subtotal
-         (if (member x date-sorting-types) #t #f)))))
+         (if (member x date-sorting-types) #t #f))
+        
+        (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-prime-subtotal
+         (or prime-sortkey-subtotal-enabled sec-sortkey-subtotal-enabled))
+        
+        (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-full-account-name
+         (or prime-sortkey-subtotal-enabled sec-sortkey-subtotal-enabled))
+         
+        (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-show-account-code
+         (or prime-sortkey-subtotal-enabled sec-sortkey-subtotal-enabled)))))
     
     (gnc:register-trep-option
      (gnc:make-simple-boolean-option

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -960,7 +960,8 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
     (gnc:register-trep-option
      (gnc:make-complex-boolean-option
       pagename-sorting optname-prime-subtotal
-      "e5" (N_ "Subtotal according to the primary key?")
+      "e5"
+      (N_ "Subtotal according to the primary key?")
       prime-sortkey-subtotal-true #f
       (lambda (x)
         (set! prime-sortkey-subtotal-true x)

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -633,7 +633,6 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
   (define (gnc:register-trep-option new-option)
     (gnc:register-option gnc:*transaction-report-options* new-option))
   
-
   ;; General options
   
   (gnc:options-add-date-interval!

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -894,8 +894,8 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
       (let* ((prime-sortkey-enabled (not (eq? prime-sortkey 'none)))
              (prime-sortkey-subtotal-enabled (member prime-sortkey subtotal-enabled))
              (prime-date-sortingtype-enabled (member prime-sortkey date-sorting-types))
-             (sec-sortkey-subtotal-enabled (member sec-sortkey subtotal-enabled))
              (sec-sortkey-enabled (not (eq? sec-sortkey 'none)))
+             (sec-sortkey-subtotal-enabled (member sec-sortkey subtotal-enabled))
              (sec-date-sortingtype-enabled (member sec-sortkey date-sorting-types)))
         
         (gnc-option-db-set-option-selectable-by-name
@@ -985,7 +985,8 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
     (gnc:register-trep-option
      (gnc:make-multichoice-callback-option
       pagename-sorting optname-sec-sortkey
-      "f" (N_ "Sort by this criterion second.")
+      "f"
+      (N_ "Sort by this criterion second.")
       sec-sortkey
       key-choice-list #f
       (lambda (x)
@@ -995,7 +996,8 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
     (gnc:register-trep-option
      (gnc:make-complex-boolean-option
       pagename-sorting optname-sec-subtotal
-      "i5" (N_ "Subtotal according to the secondary key?")
+      "i5"
+      (N_ "Subtotal according to the secondary key?")
       sec-sortkey-subtotal-true #f
       (lambda (x)
         (set! sec-sortkey-subtotal-true x)

--- a/gnucash/report/standard-reports/business-tax-report.scm
+++ b/gnucash/report/standard-reports/business-tax-report.scm
@@ -886,7 +886,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
 
         (prime-sortkey 'account-name)
         (prime-sortkey-subtotal-true #t)
-        (sec-sortkey 'none)
+        (sec-sortkey 'register-order)
         (sec-sortkey-subtotal-true #f))
     
     (define (apply-selectable-by-name-options)


### PR DESCRIPTION
This PR will change the Sorting tab usability.
By default, the Primary Key is Account Name, Secondary Key is Register Order.
This will ensure that only relevant options are presented to user.

e.g. "Subtotal for Date Key" is irrelevant for Account Name, therefore is disabled, unless a date-type key is chosen.