### PR TITLE
transaction.scm future

### DIFF
--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -9,6 +9,7 @@
 ;; Michael T. Garrison Stuber
 ;; Modified account names display by Tomas Pospisek
 ;; <tpo_deb@sourcepole.ch> with a lot of help from "warlord"
+;; Account and Transaction Filtering by Christopher Lam
 ;;
 ;; This program is free software; you can redistribute it and/or    
 ;; modify it under the terms of the GNU General Public License as   
@@ -66,8 +67,11 @@
 (define optname-currency (N_ "Report's currency"))
 (define optname-account-matcher (N_ "Account Matcher"))
 (define optname-account-matcher-regex (N_ "Account Matcher uses regular expressions for extended matching"))
+
+(define pagename-filtering (N_ "Filtering"))
 (define optname-transaction-matcher (N_ "Transaction Matcher"))
 (define optname-transaction-matcher-regex (N_ "Transaction Matcher uses regular expressions for extended matching"))
+
 (define def:grand-total-style "grand-total")
 (define def:normal-row-style "normal-row")
 (define def:alternate-row-style "alternate-row")
@@ -610,7 +614,7 @@
     split-value))
 
 
-(define date-sorting-types (list 'date 'exact-time 'register-order))
+(define date-sorting-types (list 'date 'reconciled-date 'register-order))
 
 (define (trep-options-generator)
   (define gnc:*transaction-report-options* (gnc:new-options))
@@ -646,7 +650,7 @@
 
   (gnc:register-trep-option
    (gnc:make-string-option
-    gnc:pagename-general optname-transaction-matcher
+    pagename-filtering optname-transaction-matcher
     "i1" (N_ "Match only transactions whose substring is matched e.g. '#gift' \
 will find all transactions with #gift in description, notes or memo. It can be left \
 blank, which will disable the matcher.")
@@ -654,7 +658,7 @@ blank, which will disable the matcher.")
 
   (gnc:register-trep-option
    (gnc:make-simple-boolean-option
-    gnc:pagename-general optname-transaction-matcher-regex
+    pagename-filtering optname-transaction-matcher-regex
     "i2"
     (N_ "By default the transaction matcher will search substring only. Set this to true to \
 enable full POSIX regular expressions capabilities. '#work|#family' will match both \
@@ -768,10 +772,6 @@ Use a period (.) to match a single character e.g. '20../.' will match 'Travel 20
                            (N_ "Date")
                            (N_ "Sort by date."))
 
-                   (vector 'exact-time
-                           (N_ "Exact Time")
-                           (N_ "Sort by exact time."))
-
                    (vector 'reconciled-date
                            (N_ "Reconciled Date")
                            (N_ "Sort by the Reconciled Date."))
@@ -822,10 +822,6 @@ Use a period (.) to match a single character e.g. '20../.' will match 'Travel 20
                    (vector 'date
                            (N_ "Date")
                            (N_ "Sort by date."))
-
-                   (vector 'exact-time
-                           (N_ "Exact Time")
-                           (N_ "Sort by exact time."))
 
                    (vector 'reconciled-date
                            (N_ "Reconciled Date")
@@ -1423,9 +1419,6 @@ Credit Card, and Income accounts."))))))
                                   split-account-code-same-p
                                   render-account-subheading
                                   render-account-subtotal))
-            (cons 'exact-time    (vector
-                                  (list SPLIT-TRANS TRANS-DATE-POSTED)
-                                  #f #f #f))
             (cons 'date          (vector
                                   (list SPLIT-TRANS TRANS-DATE-POSTED)
                                   #f #f #f))
@@ -1579,8 +1572,8 @@ Credit Card, and Income accounts."))))))
         (enddate (gnc:timepair-end-day-time
                   (gnc:date-option-absolute-time
                    (opt-val gnc:pagename-general "End Date"))))
-        (transaction-matcher (opt-val gnc:pagename-general optname-transaction-matcher))
-        (transaction-matcher-regexp (if (opt-val gnc:pagename-general optname-transaction-matcher-regex)
+        (transaction-matcher (opt-val pagename-filtering optname-transaction-matcher))
+        (transaction-matcher-regexp (if (opt-val pagename-filtering optname-transaction-matcher-regex)
                                         (make-regexp transaction-matcher)
                                         #f))
         (report-title (opt-val 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -996,7 +996,7 @@ Credit Card, and Income accounts."))))))
                                 (if col
                                     (set! merging-subtotal
                                           (merge-fn merging-subtotal col GNC-DENOM-AUTO GNC-RND-ROUND)))
-                                (set! width (+ width 1)))                              
+                                (set! width (+ width 1)))
                               (if merging?
                                   (begin
                                     (set! merging? #f)
@@ -1011,9 +1011,7 @@ Credit Card, and Income accounts."))))))
                                     (set! width 0)
                                     (set! merging-subtotal (gnc:make-gnc-numeric 0 1)))
                                   (addto! row-contents
-                                          (gnc:make-html-table-cell/markup
-                                           "total-number-cell"
-                                           (retrieve-commodity column commodity)))))))
+                                          (gnc:make-html-table-cell/markup "total-number-cell" mon))))))
                       columns
                       merge-list)))
 
@@ -1053,11 +1051,9 @@ Credit Card, and Income accounts."))))))
     ;                                                                                                                  
     (define calculated-cells
       (letrec
-          ((parent (lambda (s) (xaccSplitGetTransaction s)))
-           (damount (lambda (s) (if (gnc:split-voided? s)
+          ((damount (lambda (s) (if (gnc:split-voided? s)
                                     (xaccSplitVoidFormerAmount s)
-                                   (xaccSplitGetAmount s))))
-           (dont-reverse (lambda (s) #f))
+                                    (xaccSplitGetAmount s))))
            (trans-date (lambda (s) (gnc-transaction-get-date-posted (xaccSplitGetTransaction s))))
            (currency (lambda (s) (xaccAccountGetCommodity (xaccSplitGetAccount s))))
            (report-currency (lambda (s) (if (opt-val gnc:pagename-general optname-common-currency)
@@ -1072,7 +1068,6 @@ Credit Card, and Income accounts."))))))
                        ;; likely match a price on the previous day
                        (timespecCanonicalDayTime trans-date))))
            (split-value (lambda (s) (convert s (damount s)))) ; used for correct debit/credit
-           
            (amount (lambda (s) (split-value s)))
            (debit-amount (lambda (s) (if (gnc-numeric-positive-p (gnc:gnc-monetary-amount (split-value s)))
                                          (split-value s)
@@ -1272,10 +1267,10 @@ Credit Card, and Income accounts."))))))
 
         (if (column-uses? 'price used-columns)
             (addto! row-contents
-                     (gnc:make-html-table-cell/markup
-                      "number-cell"
-                      (gnc:make-gnc-monetary (xaccTransGetCurrency trans)
-                                             (xaccSplitGetSharePrice split)))))
+                    (gnc:make-html-table-cell/markup
+                     "number-cell"
+                     (gnc:make-gnc-monetary (xaccTransGetCurrency trans)
+                                            (xaccSplitGetSharePrice split)))))
 
         (for-each (lambda (cell)
                     (let ((cell-content (vector-ref cell 0))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -812,7 +812,7 @@ tags within description, notes or memo. ")
     (gnc:register-trep-option
      (gnc:make-multichoice-option
       gnc:pagename-display (N_ "Sign Reverses")
-      "p" (N_ "Reverse amount display for certain account types.")
+      "m1" (N_ "Reverse amount display for certain account types.")
       'credit-accounts
       (list (vector 'none
                     (N_ "None")
@@ -990,7 +990,6 @@ Credit Card, and Income accounts."))))))
                                (col (and mon (gnc:gnc-monetary-amount mon)))
                                (merge? (vector-ref merge-entry 0))
                                (merge-fn (vector-ref merge-entry 1)))
-                          (gnc:warn column merge? merging? merging-subtotal width)
                           (if merge?
                               (begin
                                 (set! merging? #t)
@@ -1017,11 +1016,7 @@ Credit Card, and Income accounts."))))))
                                            (retrieve-commodity column commodity)))))))
                       columns
                       merge-list)))
-          
-        (gnc:warn subtotal-collectors)
-        (gnc:warn calculated-cells)
-        (gnc:warn merge-list)
-        
+
         ;first row
         (add-first-column subtotal-string)
         (add-columns (if (pair? list-of-commodities)
@@ -1585,7 +1580,6 @@ Credit Card, and Income accounts."))))))
                         (cons 'register-order (lambda (s) #f))
                         (cons 'memo (lambda (s) (xaccSplitGetMemo s)))
                         (cons 'none (lambda (s) #f)))))))
-      ;(gnc:warn "comparing " (comparator-function X) (if ascend? "<" ">") (comparator-function Y))
       (cond
         ((string? (comparator-function X)) ((if ascend? string<? string>?) (comparator-function X) (comparator-function Y)))
         ((comparator-function X)           ((if ascend? < >)               (comparator-function X) (comparator-function Y)))
@@ -1650,8 +1644,6 @@ Credit Card, and Income accounts."))))))
             (if (opt-val pagename-filter optname-transaction-matcher-regex) "regex" "substring")
             " Matcher: </b>'" transaction-matcher "'<br>"))
        "<br>"))
-    ;;(gnc:warn "accts in trep-renderer:" c_account_1)
-    ;;(gnc:warn "Report Account names:" (get-other-account-names c_account_1))
 
     (if (or (null? c_account_1) (and-map not c_account_1))
 
@@ -1663,12 +1655,17 @@ Credit Card, and Income accounts."))))))
              (gnc:html-make-no-account-warning report-title (gnc:report-id report-obj)))
 
             ;; error condition: accounts were specified but none matched string/regex
-            (gnc:html-document-add-object!
-             document
-             (gnc:make-html-text
-              (gnc:html-markup-h2 NO-MATCHING-ACCT-HEADER)
-              (gnc:html-markup-p NO-MATCHING-ACCT-TEXT))))
+            (begin
+              (gnc:html-document-add-object!
+               document
+               (gnc:make-html-text
+                (gnc:html-markup-h2 NO-MATCHING-ACCT-HEADER)
+                (gnc:html-markup-p NO-MATCHING-ACCT-TEXT)))
 
+              (gnc:html-document-add-object!
+               document                 
+               (infobox))))
+            
         (begin
 
           (qof-query-set-book query (gnc-get-current-book))
@@ -1724,12 +1721,17 @@ Credit Card, and Income accounts."))))))
           (if (null? splits)
 
               ;; error condition: no splits found
-              (gnc:html-document-add-object!
-               document
-               (gnc:make-html-text
-                (gnc:html-markup-h2 NO-MATCHING-TRANS-HEADER)
-                (gnc:html-markup-p NO-MATCHING-TRANS-TEXT)))
-
+              (begin
+                (gnc:html-document-add-object!
+                 document
+                 (gnc:make-html-text
+                  (gnc:html-markup-h2 NO-MATCHING-TRANS-HEADER)
+                  (gnc:html-markup-p NO-MATCHING-TRANS-TEXT)))
+                
+                (gnc:html-document-add-object!
+                 document                 
+                 (infobox)))
+              
               (let ((table (make-split-table
                             splits options
                             (subtotal-get-info optname-prime-sortkey

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -9,7 +9,9 @@
 ;; Michael T. Garrison Stuber
 ;; Modified account names display by Tomas Pospisek
 ;; <tpo_deb@sourcepole.ch> with a lot of help from "warlord"
-;; Refactored by Christopher Lam
+;; Refactored by Christopher Lam (2017)
+;; - introduced account/transaction substring/regex matcher
+;; - add custom query/sorter in scheme
 ;;
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
@@ -111,22 +113,21 @@ options specified in the Options panels."))
 
 (define BOOK-SPLIT-ACTION (qof-book-use-split-action-for-num-field (gnc-get-current-book)))
 
-
-;
-;                               ;
-;                         ;     ;
-;                         ;     ;
-;    ;;;;   ;;;   ;; ;;  ;;;;;  ;   ;   ;;;   ;   ;   ;;;;
-;   ;   ;  ;   ;   ;; ;   ;     ;  ;   ;   ;  ;   ;  ;   ;
-;   ;;     ;   ;   ;      ;     ; ;    ;   ;   ;  ;  ;;
-;     ;;   ;   ;   ;      ;     ;;;    ;;;;;   ; ;     ;;
-;       ;  ;   ;   ;      ;     ; ;;   ;       ; ;       ;
-;   ;   ;  ;   ;   ;      ;     ;  ;;  ;;      ; ;   ;   ;
-;   ;;;;    ;;;   ;;;;     ;;;  ;   ;;  ;;;;    ;    ;;;;
-;                                               ;
-;                                              ;;
-;                                             ;
-;
+;                                                          
+;                               ;                          
+;                         ;     ;                          
+;                         ;     ;                          
+;    ;;;;   ;;;   ;; ;;  ;;;;;  ;   ;   ;;;   ;   ;   ;;;; 
+;   ;   ;  ;   ;   ;; ;   ;     ;  ;   ;   ;  ;   ;  ;   ; 
+;   ;;     ;   ;   ;      ;     ; ;    ;   ;   ;  ;  ;;    
+;     ;;   ;   ;   ;      ;     ;;;    ;;;;;   ; ;     ;;  
+;       ;  ;   ;   ;      ;     ; ;;   ;       ; ;       ; 
+;   ;   ;  ;   ;   ;      ;     ;  ;;  ;;      ; ;   ;   ; 
+;   ;;;;    ;;;   ;;;;     ;;;  ;   ;;  ;;;;    ;    ;;;;  
+;                                               ;          
+;                                              ;;          
+;                                             ;            
+;                                                          
 
 (define sortkey-list
   ;;
@@ -182,7 +183,7 @@ options specified in the Options panels."))
 
         (cons 'amount        (list (cons 'sortkey (list SPLIT-VALUE))
                                    (cons 'split-sortvalue #f)
-                                   (cons 'text (N_ "Amount."))
+                                   (cons 'text (N_ "Amount"))
                                    (cons 'tip (N_ "Sort by amount."))
                                    (cons 'renderer-key #f)))
 
@@ -277,23 +278,21 @@ options specified in the Options panels."))
 (define (date-subtotal-get-info sortkey info)
   (cdr (assq info (cdr (assq sortkey date-subtotal-list)))))
 
-;
-;
-;
-;
-;   ;;;;;;  ;;;;;    ;;;;;   ;;;;            ;;;;    ;;;;   ;;;;;;  ;;;;;    ;;;;   ;;   ;   ;;;;
-;     ;     ;    ;   ;       ;   ;          ;   ;;   ;   ;    ;       ;     ;   ;;  ;;   ;  ;    ;
-;     ;     ;    ;   ;       ;   ;          ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;  ;
-;     ;     ;   ;;   ;       ;   ;          ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;  ;;
-;     ;     ;;;;;    ;;;;    ;   ;  ;;;;;;  ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;    ;;;
-;     ;     ;  ;     ;       ;;;;           ;    ;   ;;;;     ;       ;     ;    ;  ;  ; ;      ;;
-;     ;     ;   ;    ;       ;              ;    ;   ;        ;       ;     ;    ;  ;  ; ;       ;
-;     ;     ;   ;;   ;       ;              ;;  ;;   ;        ;       ;     ;;  ;;  ;   ;;  ;   ;;
-;     ;     ;    ;   ;;;;;   ;               ;;;;    ;        ;     ;;;;;    ;;;;   ;   ;;  ;;;;;
-;
-;
-;
-;
+;                                                                                      
+;                                                                                      
+;  ;;;;;;; ;;;;;   ;;;;  ;;;;;          ;;;   ;;;;; ;;;;;;; ;;;;;   ;;;   ;;  ;   ;;;  
+;     ;    ;   ;   ;     ;   ;         ;   ;  ;   ;    ;      ;    ;   ;  ;;  ;  ;   ; 
+;     ;    ;   ;   ;     ;    ;        ;   ;  ;    ;   ;      ;    ;   ;  ;;  ;  ;     
+;     ;    ;   ;   ;     ;    ;        ;    ; ;    ;   ;      ;    ;    ; ; ; ;  ;;    
+;     ;    ;;;;    ;;;;  ;   ;  ;;;;;  ;    ; ;   ;    ;      ;    ;    ; ; ; ;    ;;; 
+;     ;    ;  ;    ;     ;;;;          ;    ; ;;;;     ;      ;    ;    ; ; ; ;      ; 
+;     ;    ;  ;    ;     ;             ;   ;  ;        ;      ;    ;   ;  ;  ;;      ; 
+;     ;    ;   ;   ;     ;             ;   ;  ;        ;      ;    ;   ;  ;  ;;  ;   ; 
+;     ;    ;   ;;  ;;;;  ;              ;;;   ;        ;    ;;;;;   ;;;   ;   ;  ;;;;  
+;                                                                                      
+;                                                                                      
+;                                                                                      
+;                                                                                      
 
 (define (trep-options-generator)
   (define options (gnc:new-options))
@@ -301,26 +300,36 @@ options specified in the Options panels."))
     (gnc:register-option options new-option))
 
   ;; General options
-  ;
-  ;
-  ;
-  ;                                                   ;;;
-  ;                                                     ;
-  ;        ;                                            ;
-  ;    ;;;;;   ;;;;   ; ;;;    ;;;;   ;; ;;;  ;;;;      ;
-  ;   ;   ;   ;;  ;   ;;  ;   ;;  ;    ;;  ;      ;     ;
-  ;   ;   ;   ;    ;  ;   ;;  ;    ;   ;;         ;     ;
-  ;   ;   ;   ;;;;;;  ;   ;;  ;;;;;;   ;;      ;;;;     ;
-  ;    ;;;    ;       ;   ;;  ;        ;;     ;   ;     ;
-  ;   ;       ;;      ;   ;;  ;;       ;;     ;   ;     ;
-  ;    ;;;;    ;;;;;  ;   ;;   ;;;;;  ;;;;     ;;;;;    ;;;;
-  ;        ;
-  ;   ;    ;
-  ;    ;;;;
-  ;
+
+  ;                                                   
+  ;                                             ;;;   
+  ;                                               ;   
+  ;        ;                                      ;   
+  ;    ;;;;;  ;;;   ; ;;;   ;;;   ;; ;;  ;;;;     ;   
+  ;   ;   ;  ;   ;  ;;  ;  ;   ;   ;; ;      ;    ;   
+  ;   ;   ;  ;   ;  ;   ;  ;   ;   ;         ;    ;   
+  ;   ;   ;  ;;;;;  ;   ;  ;;;;;   ;      ;;;;    ;   
+  ;    ;;;   ;      ;   ;  ;       ;     ;   ;    ;   
+  ;   ;      ;;     ;   ;  ;;      ;     ;   ;    ;   
+  ;    ;;;;   ;;;;  ;   ;   ;;;;  ;;;;   ;;;;;    ;;; 
+  ;       ;                                           
+  ;   ;   ;                                           
+  ;   ;;;;;                                           
+  ;                                                   
+
 
   (gnc:options-add-date-interval!
    options gnc:pagename-general optname-startdate optname-enddate "a")
+
+  (gnc:register-trep-option
+   (gnc:make-simple-boolean-option
+    gnc:pagename-general "Custom Query Algorithm"
+    "z1" "Use custom query instead of qof-query" #f))
+
+  (gnc:register-trep-option
+   (gnc:make-simple-boolean-option
+    gnc:pagename-general "Custom Sort Algorithm"
+    "z2" "Use custom sorting instead of qof-query" #f))
 
   (gnc:register-trep-option
    (gnc:make-complex-boolean-option
@@ -340,23 +349,22 @@ options specified in the Options panels."))
 
   ;; Filtering Options
 
-  ;
-  ;
-  ;
-  ;      ;;;    ;;    ;;;                               ;;
-  ;     ;       ;;      ;       ;                       ;;
-  ;     ;               ;       ;                                          ;
-  ;     ;      ;;;      ;     ;;;;;    ;;;;   ;; ;;;   ;;;    ; ;;;    ;;;;;
-  ;   ;;;;;      ;      ;       ;     ;;  ;    ;;  ;     ;    ;;  ;   ;   ;
-  ;     ;        ;      ;       ;     ;    ;   ;;        ;    ;   ;;  ;   ;
-  ;     ;        ;      ;       ;     ;;;;;;   ;;        ;    ;   ;;  ;   ;
-  ;     ;        ;      ;       ;     ;        ;;        ;    ;   ;;   ;;;
-  ;     ;        ;      ;       ;     ;;       ;;        ;    ;   ;;  ;
-  ;     ;      ;;;;;    ;;;;    ;;;;   ;;;;;  ;;;;     ;;;;;  ;   ;;   ;;;;
-  ;                                                                        ;
-  ;                                                                   ;    ;
-  ;                                                                    ;;;;
-  ;
+  ;                                                                 
+  ;     ;;;;   ;    ;;;                           ;                 
+  ;     ;      ;      ;     ;                     ;                 
+  ;     ;             ;     ;                                      ;
+  ;     ;     ;;      ;    ;;;;;   ;;;   ;; ;;   ;;    ; ;;;   ;;;;;
+  ;   ;;;;;    ;      ;     ;     ;   ;   ;; ;    ;    ;;  ;  ;   ; 
+  ;     ;      ;      ;     ;     ;   ;   ;       ;    ;   ;  ;   ; 
+  ;     ;      ;      ;     ;     ;;;;;   ;       ;    ;   ;  ;   ; 
+  ;     ;      ;      ;     ;     ;       ;       ;    ;   ;   ;;;  
+  ;     ;      ;      ;     ;     ;;      ;       ;    ;   ;  ;     
+  ;     ;    ;;;;;    ;;;    ;;;   ;;;;  ;;;;   ;;;;;  ;   ;   ;;;; 
+  ;                                                               ; 
+  ;                                                           ;   ; 
+  ;                                                           ;;;;; 
+  ;                                                                 
+
 
   (gnc:register-trep-option
    (gnc:make-string-option
@@ -404,24 +412,21 @@ tags within description, notes or memo. ")
           (vector '(#\y)  (N_ "Reconciled")    (N_ "Reconciled only")))))
 
   ;; Accounts options
-
-  ;
-  ;
-  ;
-  ;
-  ;                                                     ;
-  ;                                                     ;
-  ;   ;;;;      ;;;     ;;;    ;;;;   ;   ;;  ; ;;;   ;;;;;    ;;;;
-  ;       ;    ;   ;   ;   ;  ;;  ;   ;   ;;  ;;  ;     ;     ;;  ;
-  ;       ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;     ;;
-  ;    ;;;;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;       ;;;
-  ;   ;   ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;         ;
-  ;   ;   ;    ;       ;      ;;  ;   ;   ;;  ;   ;;    ;     ;   ;;
-  ;    ;;;;;    ;;;;    ;;;;   ;;;;    ;;; ;  ;   ;;    ;;;;   ;;;;
-  ;
-  ;
-  ;
-  ;
+  ;                                                          
+  ;                                                          
+  ;                                              ;           
+  ;                                              ;           
+  ;   ;;;;    ;;;;   ;;;;   ;;;   ;   ;  ; ;;;  ;;;;;   ;;;; 
+  ;       ;   ;  ;   ;  ;  ;   ;  ;   ;  ;;  ;   ;     ;   ; 
+  ;       ;  ;      ;      ;   ;  ;   ;  ;   ;   ;     ;;    
+  ;    ;;;;  ;      ;      ;   ;  ;   ;  ;   ;   ;       ;;  
+  ;   ;   ;  ;      ;      ;   ;  ;   ;  ;   ;   ;         ; 
+  ;   ;   ;   ;      ;     ;   ;  ;   ;  ;   ;   ;     ;   ; 
+  ;   ;;;;;   ;;;;   ;;;;   ;;;    ;;;;  ;   ;    ;;;  ;;;;  
+  ;                                                          
+  ;                                                          
+  ;                                                          
+  ;                                                          
 
   ;; account to do report on
   (gnc:register-trep-option
@@ -472,24 +477,22 @@ tags within description, notes or memo. ")
      (vector 'both          (N_ "Both") (N_ "Show both (and include void transactions in totals).")))))
 
   ;; Sorting options
+  ;                                                   
+  ;                                 ;                 
+  ;                         ;       ;                 
+  ;                         ;                        ;
+  ;    ;;;;   ;;;   ;; ;;  ;;;;;   ;;    ; ;;;   ;;;;;
+  ;   ;   ;  ;   ;   ;; ;   ;       ;    ;;  ;  ;   ; 
+  ;   ;;     ;   ;   ;      ;       ;    ;   ;  ;   ; 
+  ;     ;;   ;   ;   ;      ;       ;    ;   ;  ;   ; 
+  ;       ;  ;   ;   ;      ;       ;    ;   ;   ;;;  
+  ;   ;   ;  ;   ;   ;      ;       ;    ;   ;  ;     
+  ;   ;;;;    ;;;   ;;;;     ;;;  ;;;;;  ;   ;   ;;;; 
+  ;                                                 ; 
+  ;                                             ;   ; 
+  ;                                             ;;;;; 
+  ;                                                   
 
-  ;
-  ;
-  ;
-  ;                                     ;;
-  ;                             ;       ;;
-  ;                             ;                          ;
-  ;    ;;;;    ;;;;   ;; ;;;  ;;;;;    ;;;    ; ;;;    ;;;;;
-  ;   ;;  ;   ;;  ;    ;;  ;    ;        ;    ;;  ;   ;   ;
-  ;   ;;      ;    ;   ;;       ;        ;    ;   ;;  ;   ;
-  ;     ;;;   ;    ;   ;;       ;        ;    ;   ;;  ;   ;
-  ;       ;   ;    ;   ;;       ;        ;    ;   ;;   ;;;
-  ;   ;   ;;  ;;  ;    ;;       ;        ;    ;   ;;  ;
-  ;    ;;;;    ;;;;   ;;;;      ;;;;   ;;;;;  ;   ;;   ;;;;
-  ;                                                        ;
-  ;                                                   ;    ;
-  ;                                                    ;;;;
-  ;
 
   (let ((ascending-choice-list
          (list (vector 'ascend
@@ -657,24 +660,22 @@ tags within description, notes or memo. ")
       ascending-choice-list)))
 
   ;; Display options
+  ;                                                   
+  ;       ;    ;                  ;;;                 
+  ;       ;    ;                    ;                 
+  ;       ;                         ;                 
+  ;    ;;;;   ;;     ;;;;  ; ;;     ;    ;;;;   ;   ; 
+  ;   ;   ;    ;    ;   ;  ;;  ;    ;        ;  ;   ; 
+  ;   ;   ;    ;    ;;     ;   ;    ;        ;   ;  ; 
+  ;   ;   ;    ;      ;;   ;   ;    ;     ;;;;   ; ;  
+  ;   ;   ;    ;        ;  ;   ;    ;    ;   ;   ; ;  
+  ;   ;   ;    ;    ;   ;  ;   ;    ;    ;   ;   ; ;  
+  ;    ;;;;  ;;;;;  ;;;;   ;;;;     ;;;  ;;;;;    ;   
+  ;                        ;                      ;   
+  ;                        ;                     ;;   
+  ;                        ;                    ;     
+  ;                                                   
 
-  ;
-  ;
-  ;
-  ;       ;;    ;;                    ;;;
-  ;       ;;    ;;                      ;
-  ;       ;;                            ;
-  ;    ;;;;;   ;;;     ;;;;   ; ;;;     ;     ;;;;    ;    ;
-  ;   ;;  ;;     ;    ;;  ;   ;;  ;;    ;         ;   ;   ;
-  ;   ;   ;;     ;    ;;      ;    ;    ;         ;    ;  ;
-  ;   ;   ;;     ;      ;;;   ;    ;    ;      ;;;;    ;  ;
-  ;   ;   ;;     ;        ;   ;    ;    ;     ;   ;    ; ;
-  ;   ;;  ;;     ;    ;   ;;  ;;  ;     ;     ;   ;     ;;
-  ;    ;;;;;   ;;;;;   ;;;;   ; ;;;     ;;;;   ;;;;;    ;;
-  ;                           ;                         ;
-  ;                           ;                         ;
-  ;                           ;                       ;;
-  ;
 
   (let ((disp-memo? #t)
         (disp-accname? #t)
@@ -813,23 +814,21 @@ Credit Card, and Income accounts."))))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;
 ;; Here comes the big function that builds the whole table.
-;
-;
-;
-;
-;   ;;  ;;    ;;    ;;   ;   ;;;;;           ;;;;    ;;;;    ;      ;;;;;   ;;;;;;          ;;;;;;    ;;    ;;;;;    ;       ;;;;;
-;   ;;  ;;    ;;    ;;  ;    ;              ;    ;   ;   ;   ;        ;       ;               ;       ;;    ;   ;    ;       ;
-;   ;;  ;;   ; ;    ;; ;     ;              ;        ;   ;   ;        ;       ;               ;      ; ;    ;   ;;   ;       ;
-;   ;; ; ;   ;  ;   ;;;      ;              ;;       ;   ;   ;        ;       ;               ;      ;  ;   ;   ;    ;       ;
-;   ; ;; ;   ;  ;   ;;;      ;;;;   ;;;;;;    ;;;    ;   ;   ;        ;       ;     ;;;;;;    ;      ;  ;   ;;;;     ;       ;;;;
-;   ; ;; ;  ;;  ;   ;; ;     ;                  ;;   ;;;;    ;        ;       ;               ;     ;;  ;   ;   ;;   ;       ;
-;   ; ;; ;  ;;;;;;  ;; ;;    ;                   ;   ;       ;        ;       ;               ;     ;;;;;;  ;    ;   ;       ;
-;  ;;    ;  ;    ;  ;;  ;    ;              ;   ;;   ;       ;        ;       ;               ;     ;    ;  ;    ;   ;       ;
-;  ;     ; ;;    ;; ;;   ;;  ;;;;;          ;;;;;    ;       ;;;;;  ;;;;;     ;               ;    ;;    ;; ;;;;;    ;;;;;   ;;;;;
-;
-;
-;
-;
+;                                                                                                                  
+;                                                                                                                  
+;   ;   ;    ;    ;   ;;  ;;;;          ;;;   ;;;;;   ;     ;;;;; ;;;;;;;       ;;;;;;;   ;    ;;;;    ;      ;;;; 
+;   ;;  ;   ; ;   ;  ;;   ;            ;   ;  ;   ;   ;       ;      ;             ;     ; ;   ;   ;   ;      ;    
+;   ;; ; ;  ; ;   ;  ;    ;            ;      ;    ;  ;       ;      ;             ;     ; ;   ;   ;   ;      ;    
+;   ;; ; ;  ; ;   ; ;     ;            ;;     ;    ;  ;       ;      ;             ;     ; ;   ;   ;   ;      ;    
+;   ;; ; ;  ;  ;  ;;;     ;;;;  ;;;;;    ;;;  ;   ;   ;       ;      ;    ;;;;;    ;     ;  ;  ;;;;    ;      ;;;; 
+;   ; ;; ; ;   ;  ; ;;    ;                ;  ;;;;    ;       ;      ;             ;    ;   ;  ;   ;   ;      ;    
+;  ;  ;  ; ;;;;;  ;  ;    ;                ;  ;       ;       ;      ;             ;    ;;;;;  ;   ;   ;      ;    
+;  ;     ; ;   ;; ;   ;   ;            ;   ;  ;       ;       ;      ;             ;    ;   ;; ;   ;   ;      ;    
+;  ;     ;;     ; ;   ;;  ;;;;         ;;;;   ;       ;;;;  ;;;;;    ;             ;   ;     ; ;;;;    ;;;;   ;;;; 
+;                                                                                                                  
+;                                                                                                                  
+;                                                                                                                  
+;                                                                                                                  
 
 (define (make-split-table splits options
                           primary-subtotal-comparator
@@ -903,8 +902,6 @@ Credit Card, and Income accounts."))))))
              (_ "Price"))
      (add-if (column-uses? 'amount-single columns-used)
              (_ "Amount"))
-     ;; FIXME: Proper labels: what?
-     ;; formerly Debit/Credit, but not always true; change to Positive/Negative for now
      (add-if (column-uses? 'amount-double columns-used)
              (_ "Debit")
              (_ "Credit"))
@@ -961,21 +958,21 @@ Credit Card, and Income accounts."))))))
 
     (define (total-string str) (string-append (_ "Total For ") str))
     ;
-    ;
-    ;                               ;;
-    ;                               ;;
-    ;                               ;;
-    ;   ;; ;;;   ;;;;   ; ;;;    ;;;;;   ;;;;   ;; ;;;   ;;;;   ;; ;;;   ;;;;
-    ;    ;;  ;  ;;  ;   ;;  ;   ;;  ;;  ;;  ;    ;;  ;  ;;  ;    ;;  ;  ;;  ;
-    ;    ;;     ;    ;  ;   ;;  ;   ;;  ;    ;   ;;     ;    ;   ;;     ;;
-    ;    ;;     ;;;;;;  ;   ;;  ;   ;;  ;;;;;;   ;;     ;;;;;;   ;;       ;;;
-    ;    ;;     ;       ;   ;;  ;   ;;  ;        ;;     ;        ;;         ;
-    ;    ;;     ;;      ;   ;;  ;;  ;;  ;;       ;;     ;;       ;;     ;   ;;
-    ;   ;;;;     ;;;;;  ;   ;;   ;;;;;   ;;;;;  ;;;;     ;;;;;  ;;;;     ;;;;
-    ;
-    ;
-    ;
-    ;
+    ;                                                                 
+    ;                            ;                                    
+    ;                            ;                                    
+    ;                            ;                                    
+    ;   ;; ;;   ;;;   ; ;;;   ;;;;   ;;;   ;; ;;   ;;;   ;; ;;   ;;;; 
+    ;    ;; ;  ;   ;  ;;  ;  ;   ;  ;   ;   ;; ;  ;   ;   ;; ;  ;   ; 
+    ;    ;     ;   ;  ;   ;  ;   ;  ;   ;   ;     ;   ;   ;     ;;    
+    ;    ;     ;;;;;  ;   ;  ;   ;  ;;;;;   ;     ;;;;;   ;       ;;  
+    ;    ;     ;      ;   ;  ;   ;  ;       ;     ;       ;         ; 
+    ;    ;     ;;     ;   ;  ;   ;  ;;      ;     ;;      ;     ;   ; 
+    ;   ;;;;    ;;;;  ;   ;   ;;;;   ;;;;  ;;;;    ;;;;  ;;;;   ;;;;  
+    ;                                                                 
+    ;                                                                 
+    ;                                                                 
+    ;                                                                 
 
     ;; display an account name depending on the options the user has set
     (define (account-namestring account show-account-code? show-account-name? show-account-full-name?)
@@ -1028,24 +1025,21 @@ Credit Card, and Income accounts."))))))
     (define (render-grand-total)
       (_ "Grand Total"))
 
-    ;
-    ;
-    ;
-    ;
-    ;               ;;      ;;                          ;;;       ;;
-    ;               ;;      ;;                            ;       ;;      ;
-    ;               ;;      ;;                            ;               ;
-    ;   ;;;;     ;;;;;   ;;;;;           ;;;;   ; ;;;     ;      ;;;    ;;;;;           ;; ;;;   ;;;;  ;     ;;
-    ;       ;   ;;  ;;  ;;  ;;          ;;  ;   ;;  ;;    ;        ;      ;              ;;  ;  ;;  ;  ;; ;; ;
-    ;       ;   ;   ;;  ;   ;;  ;;;;;;  ;;      ;    ;    ;        ;      ;     ;;;;;;   ;;     ;    ;  ; ;; ;
-    ;    ;;;;   ;   ;;  ;   ;;            ;;;   ;    ;    ;        ;      ;              ;;     ;    ;  ; ;; ;
-    ;   ;   ;   ;   ;;  ;   ;;              ;   ;    ;    ;        ;      ;              ;;     ;    ;  ; ;; ;
-    ;   ;   ;   ;;  ;;  ;;  ;;          ;   ;;  ;;  ;     ;        ;      ;              ;;     ;;  ;   ;;  ;;
-    ;    ;;;;;   ;;;;;   ;;;;;           ;;;;   ; ;;;     ;;;;   ;;;;;    ;;;;          ;;;;     ;;;;   ;;  ;
-    ;                                           ;
-    ;                                           ;
-    ;                                           ;
-    ;
+    ;                                                                                             
+    ;              ;      ;                       ;;;      ;                                      
+    ;              ;      ;                         ;      ;     ;                                
+    ;              ;      ;                         ;            ;                                
+    ;   ;;;;    ;;;;   ;;;;          ;;;;  ; ;;     ;     ;;    ;;;;;         ;; ;;   ;;;  ;     ;
+    ;       ;  ;   ;  ;   ;         ;   ;  ;;  ;    ;      ;     ;             ;; ;  ;   ; ;  ;  ;
+    ;       ;  ;   ;  ;   ;  ;;;;;  ;;     ;   ;    ;      ;     ;     ;;;;;   ;     ;   ;  ; ;; ;
+    ;    ;;;;  ;   ;  ;   ;           ;;   ;   ;    ;      ;     ;             ;     ;   ;  ;; ;; 
+    ;   ;   ;  ;   ;  ;   ;             ;  ;   ;    ;      ;     ;             ;     ;   ;  ;; ;; 
+    ;   ;   ;  ;   ;  ;   ;         ;   ;  ;   ;    ;      ;     ;             ;     ;   ;  ;; ;; 
+    ;   ;;;;;   ;;;;   ;;;;         ;;;;   ;;;;     ;;;  ;;;;;    ;;;         ;;;;    ;;;   ;; ;; 
+    ;                                      ;                                                      
+    ;                                      ;                                                      
+    ;                                      ;                                                      
+    ;                                                                                             
 
     (define (add-split-row split row-style transaction-row?)
       (let* ((row-contents '())
@@ -1100,7 +1094,8 @@ Credit Card, and Income accounts."))))))
                     (if transaction-row?
                         (if BOOK-SPLIT-ACTION
                             (let* ((num (gnc-get-num-action parent split))
-                                   (t-num (if (if (gnc:lookup-option options gnc:pagename-display
+                                   (t-num (if (if (gnc:lookup-option options
+                                                                     gnc:pagename-display
                                                                      (N_ "Trans Number"))
                                                   (opt-val gnc:pagename-display (N_ "Trans Number"))
                                                   "")
@@ -1185,24 +1180,21 @@ Credit Card, and Income accounts."))))))
 
         split-value-not-reversed))
 
-
-
-
-    ;
-    ;                                                                  ;                                  ;;;
-    ;                                                                  ;       ;             ;              ;
-    ;                                                                  ;       ;             ;              ;
-    ;   ;; ;;   ;;;  ;     ;  ;;;;        ;     ;         ;;;;  ;   ;  ; ;;   ;;;;;   ;;;   ;;;;;  ;;;;     ;     ;;;;
-    ;    ;; ;  ;   ; ;  ;  ; ;   ;        ;  ;  ;        ;   ;  ;   ;  ;;  ;   ;     ;   ;   ;         ;    ;    ;   ;
-    ;    ;     ;   ;  ; ;; ; ;;     ;;;;;  ; ;; ; ;;;;;  ;;     ;   ;  ;   ;   ;     ;   ;   ;         ;    ;    ;;
-    ;    ;     ;   ;  ;; ;;    ;;          ;; ;;           ;;   ;   ;  ;   ;   ;     ;   ;   ;      ;;;;    ;      ;;
-    ;    ;     ;   ;  ;; ;;      ;         ;; ;;             ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;        ;
-    ;    ;     ;   ;  ;; ;;  ;   ;         ;; ;;         ;   ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;    ;   ;
-    ;   ;;;;    ;;;   ;; ;;  ;;;;          ;; ;;         ;;;;    ;;;;  ;;;;     ;;;   ;;;     ;;;  ;;;;;    ;;;  ;;;;
-    ;
-    ;
-    ;
-    ;
+    ;                                                                                                                  
+    ;                                                                  ;                                  ;;;          
+    ;                                                                  ;       ;             ;              ;          
+    ;                                                                  ;       ;             ;              ;          
+    ;   ;; ;;   ;;;  ;     ;  ;;;;        ;     ;         ;;;;  ;   ;  ; ;;   ;;;;;   ;;;   ;;;;;  ;;;;     ;     ;;;; 
+    ;    ;; ;  ;   ; ;  ;  ; ;   ;        ;  ;  ;        ;   ;  ;   ;  ;;  ;   ;     ;   ;   ;         ;    ;    ;   ; 
+    ;    ;     ;   ;  ; ;; ; ;;     ;;;;;  ; ;; ; ;;;;;  ;;     ;   ;  ;   ;   ;     ;   ;   ;         ;    ;    ;;    
+    ;    ;     ;   ;  ;; ;;    ;;          ;; ;;           ;;   ;   ;  ;   ;   ;     ;   ;   ;      ;;;;    ;      ;;  
+    ;    ;     ;   ;  ;; ;;      ;         ;; ;;             ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;        ; 
+    ;    ;     ;   ;  ;; ;;  ;   ;         ;; ;;         ;   ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;    ;   ; 
+    ;   ;;;;    ;;;   ;; ;;  ;;;;          ;; ;;         ;;;;    ;;;;  ;;;;     ;;;   ;;;     ;;;  ;;;;;    ;;;  ;;;;  
+    ;                                                                                                                  
+    ;                                                                                                                  
+    ;                                                                                                                  
+    ;                                                                                                                  
 
 
     (define (do-rows-with-subtotals splits
@@ -1319,24 +1311,21 @@ Credit Card, and Income accounts."))))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;
 ;; Here comes the renderer function for this report.
-
-;
-;
-;
-;
-;   ;;;;;;  ;;;;;    ;;;;;   ;;;;           ;;;;;    ;;;;;  ;;   ;  ;;;;     ;;;;;  ;;;;;    ;;;;;  ;;;;;
-;     ;     ;    ;   ;       ;   ;          ;    ;   ;      ;;   ;  ;   ;;   ;      ;    ;   ;      ;    ;
-;     ;     ;    ;   ;       ;   ;          ;    ;   ;      ; ;  ;  ;    ;   ;      ;    ;   ;      ;    ;
-;     ;     ;   ;;   ;       ;   ;          ;   ;;   ;      ; ;  ;  ;    ;   ;      ;   ;;   ;      ;   ;;
-;     ;     ;;;;;    ;;;;    ;   ;  ;;;;;;  ;;;;;    ;;;;   ; ;  ;  ;    ;   ;;;;   ;;;;;    ;;;;   ;;;;;
-;     ;     ;  ;     ;       ;;;;           ;  ;     ;      ;  ; ;  ;    ;   ;      ;  ;     ;      ;  ;
-;     ;     ;   ;    ;       ;              ;   ;    ;      ;  ; ;  ;    ;   ;      ;   ;    ;      ;   ;
-;     ;     ;   ;;   ;       ;              ;   ;;   ;      ;   ;;  ;   ;    ;      ;   ;;   ;      ;   ;;
-;     ;     ;    ;   ;;;;;   ;              ;    ;   ;;;;;  ;   ;;  ;;;;     ;;;;;  ;    ;   ;;;;;  ;    ;
-;
-;
-;
-;
+;                                                                                             
+;                                                                                             
+;  ;;;;;;; ;;;;;   ;;;;  ;;;;;         ;;;;;   ;;;;  ;;  ;  ;;;;    ;;;;  ;;;;;   ;;;;  ;;;;; 
+;     ;    ;   ;   ;     ;   ;         ;   ;   ;     ;;  ;  ;   ;   ;     ;   ;   ;     ;   ; 
+;     ;    ;   ;   ;     ;    ;        ;   ;   ;     ;;  ;  ;   ;   ;     ;   ;   ;     ;   ; 
+;     ;    ;   ;   ;     ;    ;        ;   ;   ;     ; ; ;  ;   ;;  ;     ;   ;   ;     ;   ; 
+;     ;    ;;;;    ;;;;  ;   ;  ;;;;;  ;;;;    ;;;;  ; ; ;  ;    ;  ;;;;  ;;;;    ;;;;  ;;;;  
+;     ;    ;  ;    ;     ;;;;          ;  ;    ;     ; ; ;  ;   ;;  ;     ;  ;    ;     ;  ;  
+;     ;    ;  ;    ;     ;             ;  ;    ;     ;  ;;  ;   ;   ;     ;  ;    ;     ;  ;  
+;     ;    ;   ;   ;     ;             ;   ;   ;     ;  ;;  ;   ;   ;     ;   ;   ;     ;   ; 
+;     ;    ;   ;;  ;;;;  ;             ;   ;;  ;;;;  ;   ;  ;;;;    ;;;;  ;   ;;  ;;;;  ;   ;;
+;                                                                                             
+;                                                                                             
+;                                                                                             
+;                                                                                             
 
 (define (trep-renderer report-obj)
   (define options (gnc:report-options report-obj))
@@ -1410,8 +1399,71 @@ Credit Card, and Income accounts."))))))
          (secondary-order (opt-val pagename-sorting optname-sec-sortorder))
          (void-status (opt-val gnc:pagename-accounts optname-void-transactions))
          (splits '())
+         (custom-query? (opt-val gnc:pagename-general "Custom Query Algorithm"))
+         (custom-sort? (opt-val gnc:pagename-general "Custom Sort Algorithm"))
          (query (qof-query-create-for-splits)))
 
+    (define (generic-less? X Y key date-subtotal ascend?)
+      (define comparator-function
+        (if (member key DATE-SORTING-TYPES)
+            (let* ((date (lambda (s)
+                           (cdr
+                            (assq key
+                                  (list
+                                   (cons 'date (gnc-transaction-get-date-posted (xaccSplitGetParent s)))
+                                   (cons 'reconciled-date (gnc-split-get-date-reconciled s)))))))
+                   (year (lambda (s) (gnc:timepair-get-year (date s))))
+                   (month (lambda (s) (gnc:timepair-get-month (date s))))
+                   (quarter (lambda (s) (gnc:timepair-get-quarter (date s))))
+                   (week (lambda (s) (gnc:timepair-get-week (date s))))
+                   (secs (lambda (s) (gnc:timepair->secs (date s)))))
+              (cdr
+               (assq date-subtotal
+                     (list
+                      (cons 'yearly    (lambda (s) (year s)))
+                      (cons 'monthly   (lambda (s) (+ (* 100 (year s)) (month s))))
+                      (cons 'quarterly (lambda (s) (+ (*  10 (year s)) (quarter s))))
+                      (cons 'weekly    (lambda (s) (+ (* 100 (year s)) (week s))))
+                      (cons 'none      (lambda (s) (secs s)))))))
+            (cdr (assq key
+                       (list
+                        (cons 'account-name (lambda (s) (gnc-account-get-full-name (xaccSplitGetAccount s))))
+                        (cons 'account-code (lambda (s) (xaccAccountGetCode (xaccSplitGetAccount s))))
+                        (cons 'corresponding-acc-name (lambda (s) (xaccSplitGetCorrAccountFullName s)))
+                        (cons 'corresponding-acc-code (lambda (s) (xaccSplitGetCorrAccountCode s)))
+                        (cons 'amount (lambda (s) (let* ((val (xaccSplitGetValue s))
+                                                         (num (gnc:gnc-numeric-num val))
+                                                         (denom (gnc:gnc-numeric-denom val)))
+                                                    (/ num denom 1.0))))
+                        (cons 'description (lambda (s) (xaccTransGetDescription (xaccSplitGetParent s))))
+                        (cons 'number (lambda (s)
+                                        (if (qof-book-use-split-action-for-num-field (gnc-get-current-book))
+                                            (xaccSplitGetAction s)
+                                            (xaccTransGetNum (xaccSplitGetParent s)))))
+                        (cons 't-number (lambda (s) (xaccTransGetNum (xaccSplitGetParent s))))
+                        (cons 'register-order (lambda (s) #f))
+                        (cons 'memo (lambda (s) (xaccSplitGetMemo s)))
+                        (cons 'none (lambda (s) #f)))))))
+      ;(gnc:warn "comparing " (comparator-function X) (if ascend? "<" ">") (comparator-function Y))
+      (cond
+        ((string? (comparator-function X)) ((if ascend? string<? string>?) (comparator-function X) (comparator-function Y)))
+        ((comparator-function X)           ((if ascend? < >)               (comparator-function X) (comparator-function Y)))
+        (else                              #f)))
+    
+    (define (primary-comparator? X Y)
+      (generic-less? X Y primary-key 
+                     (opt-val pagename-sorting optname-prime-date-subtotal)
+                     (eq? primary-order 'ascend)))
+    
+    (define (secondary-comparator? X Y)
+      (generic-less? X Y secondary-key 
+                     (opt-val pagename-sorting optname-sec-date-subtotal)
+                     (eq? secondary-order 'ascend)))
+
+    ; This will, by default, sort the split list by ascending posted-date.
+    (define (date-comparator? X Y) 
+      (generic-less? X Y 'date 'none #t))
+    
     ;;(gnc:warn "accts in trep-renderer:" c_account_1)
     ;;(gnc:warn "Report Account names:" (get-other-account-names c_account_1))
 
@@ -1424,7 +1476,7 @@ Credit Card, and Income accounts."))))))
              document
              (gnc:html-make-no-account-warning report-title (gnc:report-id report-obj)))
 
-            ;; error condition: accounts were specified but none matcher string/regex
+            ;; error condition: accounts were specified but none matched string/regex
             (gnc:html-document-add-object!
              document
              (gnc:make-html-text
@@ -1433,28 +1485,52 @@ Credit Card, and Income accounts."))))))
 
         (begin
 
-          (qof-query-set-book query (gnc-get-current-book))
-          (xaccQueryAddAccountMatch query c_account_1 QOF-GUID-MATCH-ANY QOF-QUERY-AND)
-          (xaccQueryAddDateMatchTS query #t begindate #t enddate QOF-QUERY-AND)
-          (qof-query-set-sort-order query
-                                    (sortkey-get-info primary-key 'sortkey)
-                                    (sortkey-get-info secondary-key 'sortkey)
-                                    '())
-          (qof-query-set-sort-increasing query
-                                         (eq? primary-order 'ascend)
-                                         (eq? secondary-order 'ascend)
-                                         #t)
-          (case void-status
-            ((non-void-only) (gnc:query-set-match-non-voids-only! query (gnc-get-current-book)))
-            ((void-only)     (gnc:query-set-match-voids-only! query (gnc-get-current-book)))
-            (else #f))
-          (set! splits (qof-query-run query))
+          (if (not custom-query?)
 
-          ; this qof-query destroyer was formerly after
-          ; (gnc:html-document-add-object! document table) --
-          ; move it here
-          (qof-query-destroy query)
+              (begin              
+                (qof-query-set-book query (gnc-get-current-book))
+                (xaccQueryAddAccountMatch query c_account_1 QOF-GUID-MATCH-ANY QOF-QUERY-AND)
+                (xaccQueryAddDateMatchTS query #t begindate #t enddate QOF-QUERY-AND)
+                (case void-status
+                  ((non-void-only) (gnc:query-set-match-non-voids-only! query (gnc-get-current-book)))
+                  ((void-only)     (gnc:query-set-match-voids-only! query (gnc-get-current-book)))
+                  (else #f))
+                (if (not custom-sort?)
+                    (begin
+                      (qof-query-set-sort-order query
+                                                (sortkey-get-info primary-key 'sortkey)
+                                                (sortkey-get-info secondary-key 'sortkey)
+                                                '())
+                      (qof-query-set-sort-increasing query
+                                                     (eq? primary-order 'ascend)
+                                                     (eq? secondary-order 'ascend)
+                                                     #t)))
+                (set! splits (qof-query-run query))                
+                ; this qof-query destroyer was formerly after
+                ; (gnc:html-document-add-object! document table) --
+                ; move it here
+                (qof-query-destroy query))
 
+              (begin
+                (set! splits (filter
+                              (lambda (split)
+                                (let* ((trans (xaccSplitGetParent split))
+                                       (trans-date (gnc-transaction-get-date-posted trans))
+                                       (void (xaccTransGetVoidStatus trans)))
+                                  (and (>= (car trans-date) (car begindate))
+                                       (<= (car trans-date) (car enddate))
+                                       (case void-status
+                                         ((both) #t)
+                                         ((non-void-only) (not void))
+                                         ((void-only) void)))))
+                              (concatenate! (map xaccAccountGetSplitList c_account_1))))))
+          
+          (if (or custom-sort? custom-query?)
+              (begin
+                (set! splits (stable-sort! splits date-comparator?))
+                (set! splits (stable-sort! splits secondary-comparator?))
+                (set! splits (stable-sort! splits primary-comparator?))))
+          
           ; Combined Filter:
           ; - include/exclude splits to/from selected accounts
           ; - substring/regex matcher for Transaction Description/Notes/Memo
@@ -1514,6 +1590,53 @@ Credit Card, and Income accounts."))))))
                             (_ "From %s to %s")
                             (gnc-print-date begindate)
                             (gnc-print-date enddate)))))
+
+                (gnc:html-document-add-object!
+                 document
+                 (gnc:make-html-text
+                  ;"<h3>Summary of settings used</h3>"
+                  ;"<b>Accounts selected: </b>" (string-join (map xaccAccountGetName c_account_0) ", ") "<br>"
+                  (if (string-null? account-matcher)
+                      ""
+                      (string-append
+                       "<b>Account "
+                       (if (opt-val pagename-filter optname-account-matcher-regex) "regex" "substring")
+                       " Matcher: </b>'" account-matcher "'<br><b>Accounts produced: </b>"
+                       (string-join (map xaccAccountGetName c_account_1) ", ") "<br>"))
+                  (if (eq? filter-mode 'none)
+                      ""
+                      (string-append
+                       "<b>Filters used : " (symbol->string filter-mode) " accounts</b> "
+                       (string-join (map xaccAccountGetName c_account_2) ", ") "<br>"))
+                  (if (eq? primary-key 'none)
+                      ""
+                      (string-append
+                       "<b>Primary SortKey: </b>" (symbol->string primary-key) " "
+                       (symbol->string primary-order) "ing "
+                       (if (eq? primary-key 'date)
+                           (string-append "with "
+                                          (symbol->string (opt-val pagename-sorting optname-prime-date-subtotal))
+                                          " subtotals")
+                           "")
+                       "<br>"))
+                  (if (eq? secondary-key 'none)
+                      ""
+                      (string-append
+                       "<b>Secondary SortKey: </b>" (symbol->string secondary-key) " "
+                       (symbol->string secondary-order) "ing "
+                       (if (eq? secondary-key 'date)
+                           (string-append "with "
+                                          (symbol->string (opt-val pagename-sorting optname-sec-date-subtotal))
+                                          " subtotals")
+                           "")
+                       "<br>"))
+                  (if (string-null? transaction-matcher)
+                      ""
+                      (string-append
+                       "<b>Transaction "
+                       (if (opt-val pagename-filter optname-transaction-matcher-regex) "regex" "substring")
+                       " Matcher: </b>'" transaction-matcher "'<br>"))
+                  "<br>"))
 
                 (gnc:html-document-add-object! document table)))))
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -11,16 +11,16 @@
 ;; <tpo_deb@sourcepole.ch> with a lot of help from "warlord"
 ;; Refactored by Christopher Lam
 ;;
-;; This program is free software; you can redistribute it and/or    
-;; modify it under the terms of the GNU General Public License as   
-;; published by the Free Software Foundation; either version 2 of   
-;; the License, or (at your option) any later version.              
-;;                                                                  
-;; This program is distributed in the hope that it will be useful,  
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of   
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    
-;; GNU General Public License for more details.                     
-;;                                                                  
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2 of
+;; the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program; if not, contact:
 ;;
@@ -65,6 +65,7 @@
 (define optname-prime-date-subtotal (N_ "Primary Subtotal for Date Key"))
 (define optname-full-account-name (N_ "Show Full Account Name"))
 (define optname-show-account-code (N_ "Show Account Code"))
+(define optname-show-account-description (N_ "Show Account Description"))
 (define optname-sec-sortkey (N_ "Secondary Key"))
 (define optname-sec-subtotal (N_ "Secondary Subtotal"))
 (define optname-sec-sortorder  (N_ "Secondary Sort Order"))
@@ -111,26 +112,26 @@ options specified in the Options panels."))
 (define BOOK-SPLIT-ACTION (qof-book-use-split-action-for-num-field (gnc-get-current-book)))
 
 
-;                                                          
-;                               ;                          
-;                         ;     ;                          
-;                         ;     ;                          
-;    ;;;;   ;;;   ;; ;;  ;;;;;  ;   ;   ;;;   ;   ;   ;;;; 
-;   ;   ;  ;   ;   ;; ;   ;     ;  ;   ;   ;  ;   ;  ;   ; 
-;   ;;     ;   ;   ;      ;     ; ;    ;   ;   ;  ;  ;;    
-;     ;;   ;   ;   ;      ;     ;;;    ;;;;;   ; ;     ;;  
-;       ;  ;   ;   ;      ;     ; ;;   ;       ; ;       ; 
-;   ;   ;  ;   ;   ;      ;     ;  ;;  ;;      ; ;   ;   ; 
-;   ;;;;    ;;;   ;;;;     ;;;  ;   ;;  ;;;;    ;    ;;;;  
-;                                               ;          
-;                                              ;;          
-;                                             ;            
-;                                                          
+;
+;                               ;
+;                         ;     ;
+;                         ;     ;
+;    ;;;;   ;;;   ;; ;;  ;;;;;  ;   ;   ;;;   ;   ;   ;;;;
+;   ;   ;  ;   ;   ;; ;   ;     ;  ;   ;   ;  ;   ;  ;   ;
+;   ;;     ;   ;   ;      ;     ; ;    ;   ;   ;  ;  ;;
+;     ;;   ;   ;   ;      ;     ;;;    ;;;;;   ; ;     ;;
+;       ;  ;   ;   ;      ;     ; ;;   ;       ; ;       ;
+;   ;   ;  ;   ;   ;      ;     ;  ;;  ;;      ; ;   ;   ;
+;   ;;;;    ;;;   ;;;;     ;;;  ;   ;;  ;;;;    ;    ;;;;
+;                                               ;
+;                                              ;;
+;                                             ;
+;
 
 (define sortkey-list
   ;;
-  ;; Defines the different sorting keys, as an association-list 
-  ;; together with the subtotal functions. Each entry: 
+  ;; Defines the different sorting keys, as an association-list
+  ;; together with the subtotal functions. Each entry:
   ;;  'sortkey             - sort parameter sent via qof-query
   ;;  'split-sortvalue     - function which retrieves number/string used for comparing splits
   ;;  'text                - text displayed in Display tab
@@ -142,7 +143,7 @@ options specified in the Options panels."))
                                    (cons 'text (N_ "Account Name"))
                                    (cons 'tip (N_ "Sort & subtotal by account name."))
                                    (cons 'renderer-key 'account)))
-        
+
         (cons 'account-code (list (cons 'sortkey (list SPLIT-ACCOUNT ACCOUNT-CODE-))
                                   (cons 'split-sortvalue (lambda (a) (xaccAccountGetCode (xaccSplitGetAccount a))))
                                   (cons 'text (N_ "Account Code"))
@@ -165,7 +166,7 @@ options specified in the Options panels."))
                                     (cons 'split-sortvalue #f)
                                     (cons 'text (N_ "Register Order"))
                                     (cons 'tip (N_ "Sort as in the register."))
-                                    (cons 'renderer-key #f)))                                 
+                                    (cons 'renderer-key #f)))
 
         (cons 'corresponding-acc-name (list (cons 'sortkey (list SPLIT-CORR-ACCT-NAME))
                                             (cons 'split-sortvalue (lambda (a) (xaccSplitGetCorrAccountFullName a)))
@@ -236,8 +237,8 @@ options specified in the Options panels."))
 (define (split-year a) (timepair-year (gnc-transaction-get-date-posted (xaccSplitGetParent a))))
 
 (define date-subtotal-list
-  ;; List for date option. 
-  ;; Defines the different date sorting keys, as an association-list. Each entry: 
+  ;; List for date option.
+  ;; Defines the different date sorting keys, as an association-list. Each entry:
   ;;  'split-sortvalue     - function which retrieves number/string used for comparing splits
   ;;  'text                - text displayed in Display tab
   ;;  'tip                 - tooltip displayed in Display tab
@@ -276,23 +277,23 @@ options specified in the Options panels."))
 (define (date-subtotal-get-info sortkey info)
   (cdr (assq info (cdr (assq sortkey date-subtotal-list)))))
 
-;                                                                                                  
-;                                                                                                  
-;                                                                                                  
-;                                                                                                  
-;   ;;;;;;  ;;;;;    ;;;;;   ;;;;            ;;;;    ;;;;   ;;;;;;  ;;;;;    ;;;;   ;;   ;   ;;;;  
-;     ;     ;    ;   ;       ;   ;          ;   ;;   ;   ;    ;       ;     ;   ;;  ;;   ;  ;    ; 
-;     ;     ;    ;   ;       ;   ;          ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;  ;      
-;     ;     ;   ;;   ;       ;   ;          ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;  ;;     
-;     ;     ;;;;;    ;;;;    ;   ;  ;;;;;;  ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;    ;;;  
-;     ;     ;  ;     ;       ;;;;           ;    ;   ;;;;     ;       ;     ;    ;  ;  ; ;      ;; 
-;     ;     ;   ;    ;       ;              ;    ;   ;        ;       ;     ;    ;  ;  ; ;       ; 
-;     ;     ;   ;;   ;       ;              ;;  ;;   ;        ;       ;     ;;  ;;  ;   ;;  ;   ;; 
-;     ;     ;    ;   ;;;;;   ;               ;;;;    ;        ;     ;;;;;    ;;;;   ;   ;;  ;;;;;  
-;                                                                                                  
-;                                                                                                  
-;                                                                                                  
-;                                                                                                  
+;
+;
+;
+;
+;   ;;;;;;  ;;;;;    ;;;;;   ;;;;            ;;;;    ;;;;   ;;;;;;  ;;;;;    ;;;;   ;;   ;   ;;;;
+;     ;     ;    ;   ;       ;   ;          ;   ;;   ;   ;    ;       ;     ;   ;;  ;;   ;  ;    ;
+;     ;     ;    ;   ;       ;   ;          ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;  ;
+;     ;     ;   ;;   ;       ;   ;          ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;  ;;
+;     ;     ;;;;;    ;;;;    ;   ;  ;;;;;;  ;    ;   ;   ;    ;       ;     ;    ;  ; ;  ;    ;;;
+;     ;     ;  ;     ;       ;;;;           ;    ;   ;;;;     ;       ;     ;    ;  ;  ; ;      ;;
+;     ;     ;   ;    ;       ;              ;    ;   ;        ;       ;     ;    ;  ;  ; ;       ;
+;     ;     ;   ;;   ;       ;              ;;  ;;   ;        ;       ;     ;;  ;;  ;   ;;  ;   ;;
+;     ;     ;    ;   ;;;;;   ;               ;;;;    ;        ;     ;;;;;    ;;;;   ;   ;;  ;;;;;
+;
+;
+;
+;
 
 (define (trep-options-generator)
   (define options (gnc:new-options))
@@ -300,27 +301,27 @@ options specified in the Options panels."))
     (gnc:register-option options new-option))
 
   ;; General options
-  ;                                                          
-  ;                                                          
-  ;                                                          
-  ;                                                   ;;;    
-  ;                                                     ;    
-  ;        ;                                            ;    
-  ;    ;;;;;   ;;;;   ; ;;;    ;;;;   ;; ;;;  ;;;;      ;    
-  ;   ;   ;   ;;  ;   ;;  ;   ;;  ;    ;;  ;      ;     ;    
-  ;   ;   ;   ;    ;  ;   ;;  ;    ;   ;;         ;     ;    
-  ;   ;   ;   ;;;;;;  ;   ;;  ;;;;;;   ;;      ;;;;     ;    
-  ;    ;;;    ;       ;   ;;  ;        ;;     ;   ;     ;    
-  ;   ;       ;;      ;   ;;  ;;       ;;     ;   ;     ;    
-  ;    ;;;;    ;;;;;  ;   ;;   ;;;;;  ;;;;     ;;;;;    ;;;; 
-  ;        ;                                                 
-  ;   ;    ;                                                 
-  ;    ;;;;                                                  
-  ;                                                          
+  ;
+  ;
+  ;
+  ;                                                   ;;;
+  ;                                                     ;
+  ;        ;                                            ;
+  ;    ;;;;;   ;;;;   ; ;;;    ;;;;   ;; ;;;  ;;;;      ;
+  ;   ;   ;   ;;  ;   ;;  ;   ;;  ;    ;;  ;      ;     ;
+  ;   ;   ;   ;    ;  ;   ;;  ;    ;   ;;         ;     ;
+  ;   ;   ;   ;;;;;;  ;   ;;  ;;;;;;   ;;      ;;;;     ;
+  ;    ;;;    ;       ;   ;;  ;        ;;     ;   ;     ;
+  ;   ;       ;;      ;   ;;  ;;       ;;     ;   ;     ;
+  ;    ;;;;    ;;;;;  ;   ;;   ;;;;;  ;;;;     ;;;;;    ;;;;
+  ;        ;
+  ;   ;    ;
+  ;    ;;;;
+  ;
 
   (gnc:options-add-date-interval!
    options gnc:pagename-general optname-startdate optname-enddate "a")
-    
+
   (gnc:register-trep-option
    (gnc:make-complex-boolean-option
     gnc:pagename-general optname-common-currency
@@ -335,27 +336,27 @@ options specified in the Options panels."))
   (gnc:register-trep-option
    (gnc:make-simple-boolean-option
     gnc:pagename-general optname-table-export
-    "g" (N_ "Formats the table suitable for cut & paste exporting with extra cells.") #f))  
+    "g" (N_ "Formats the table suitable for cut & paste exporting with extra cells.") #f))
 
   ;; Filtering Options
-  
-  ;                                                                          
-  ;                                                                          
-  ;                                                                          
-  ;      ;;;    ;;    ;;;                               ;;                   
-  ;     ;       ;;      ;       ;                       ;;                   
-  ;     ;               ;       ;                                          ; 
-  ;     ;      ;;;      ;     ;;;;;    ;;;;   ;; ;;;   ;;;    ; ;;;    ;;;;; 
-  ;   ;;;;;      ;      ;       ;     ;;  ;    ;;  ;     ;    ;;  ;   ;   ;  
-  ;     ;        ;      ;       ;     ;    ;   ;;        ;    ;   ;;  ;   ;  
-  ;     ;        ;      ;       ;     ;;;;;;   ;;        ;    ;   ;;  ;   ;  
-  ;     ;        ;      ;       ;     ;        ;;        ;    ;   ;;   ;;;   
-  ;     ;        ;      ;       ;     ;;       ;;        ;    ;   ;;  ;      
-  ;     ;      ;;;;;    ;;;;    ;;;;   ;;;;;  ;;;;     ;;;;;  ;   ;;   ;;;;  
-  ;                                                                        ; 
-  ;                                                                   ;    ; 
-  ;                                                                    ;;;;  
-  ;                                                                          
+
+  ;
+  ;
+  ;
+  ;      ;;;    ;;    ;;;                               ;;
+  ;     ;       ;;      ;       ;                       ;;
+  ;     ;               ;       ;                                          ;
+  ;     ;      ;;;      ;     ;;;;;    ;;;;   ;; ;;;   ;;;    ; ;;;    ;;;;;
+  ;   ;;;;;      ;      ;       ;     ;;  ;    ;;  ;     ;    ;;  ;   ;   ;
+  ;     ;        ;      ;       ;     ;    ;   ;;        ;    ;   ;;  ;   ;
+  ;     ;        ;      ;       ;     ;;;;;;   ;;        ;    ;   ;;  ;   ;
+  ;     ;        ;      ;       ;     ;        ;;        ;    ;   ;;   ;;;
+  ;     ;        ;      ;       ;     ;;       ;;        ;    ;   ;;  ;
+  ;     ;      ;;;;;    ;;;;    ;;;;   ;;;;;  ;;;;     ;;;;;  ;   ;;   ;;;;
+  ;                                                                        ;
+  ;                                                                   ;    ;
+  ;                                                                    ;;;;
+  ;
 
   (gnc:register-trep-option
    (gnc:make-string-option
@@ -374,7 +375,7 @@ enable full POSIX regular expressions capabilities. 'Car|Flights' will match bot
 Expenses:Car and Expenses:Flights. Use a period (.) to match a single character e.g. \
 '20../.' will match 'Travel 2017/1 London'. ")
     #f))
-  
+
   (gnc:register-trep-option
    (gnc:make-string-option
     pagename-filter optname-transaction-matcher
@@ -403,24 +404,24 @@ tags within description, notes or memo. ")
           (vector '(#\y)  (N_ "Reconciled")    (N_ "Reconciled only")))))
 
   ;; Accounts options
-  
-  ;                                                                  
-  ;                                                                  
-  ;                                                                  
-  ;                                                                  
-  ;                                                     ;            
-  ;                                                     ;            
-  ;   ;;;;      ;;;     ;;;    ;;;;   ;   ;;  ; ;;;   ;;;;;    ;;;;  
-  ;       ;    ;   ;   ;   ;  ;;  ;   ;   ;;  ;;  ;     ;     ;;  ;  
-  ;       ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;     ;;     
-  ;    ;;;;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;       ;;;  
-  ;   ;   ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;         ;  
-  ;   ;   ;    ;       ;      ;;  ;   ;   ;;  ;   ;;    ;     ;   ;; 
-  ;    ;;;;;    ;;;;    ;;;;   ;;;;    ;;; ;  ;   ;;    ;;;;   ;;;;  
-  ;                                                                  
-  ;                                                                  
-  ;                                                                  
-  ;                                                                  
+
+  ;
+  ;
+  ;
+  ;
+  ;                                                     ;
+  ;                                                     ;
+  ;   ;;;;      ;;;     ;;;    ;;;;   ;   ;;  ; ;;;   ;;;;;    ;;;;
+  ;       ;    ;   ;   ;   ;  ;;  ;   ;   ;;  ;;  ;     ;     ;;  ;
+  ;       ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;     ;;
+  ;    ;;;;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;       ;;;
+  ;   ;   ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;         ;
+  ;   ;   ;    ;       ;      ;;  ;   ;   ;;  ;   ;;    ;     ;   ;;
+  ;    ;;;;;    ;;;;    ;;;;   ;;;;    ;;; ;  ;   ;;    ;;;;   ;;;;
+  ;
+  ;
+  ;
+  ;
 
   ;; account to do report on
   (gnc:register-trep-option
@@ -471,26 +472,26 @@ tags within description, notes or memo. ")
      (vector 'both          (N_ "Both") (N_ "Show both (and include void transactions in totals).")))))
 
   ;; Sorting options
-  
-  ;                                                          
-  ;                                                          
-  ;                                                          
-  ;                                     ;;                   
-  ;                             ;       ;;                   
-  ;                             ;                          ; 
-  ;    ;;;;    ;;;;   ;; ;;;  ;;;;;    ;;;    ; ;;;    ;;;;; 
-  ;   ;;  ;   ;;  ;    ;;  ;    ;        ;    ;;  ;   ;   ;  
-  ;   ;;      ;    ;   ;;       ;        ;    ;   ;;  ;   ;  
-  ;     ;;;   ;    ;   ;;       ;        ;    ;   ;;  ;   ;  
-  ;       ;   ;    ;   ;;       ;        ;    ;   ;;   ;;;   
-  ;   ;   ;;  ;;  ;    ;;       ;        ;    ;   ;;  ;      
-  ;    ;;;;    ;;;;   ;;;;      ;;;;   ;;;;;  ;   ;;   ;;;;  
-  ;                                                        ; 
-  ;                                                   ;    ; 
-  ;                                                    ;;;;  
-  ;                                                          
 
-  (let ((ascending-choice-list 
+  ;
+  ;
+  ;
+  ;                                     ;;
+  ;                             ;       ;;
+  ;                             ;                          ;
+  ;    ;;;;    ;;;;   ;; ;;;  ;;;;;    ;;;    ; ;;;    ;;;;;
+  ;   ;;  ;   ;;  ;    ;;  ;    ;        ;    ;;  ;   ;   ;
+  ;   ;;      ;    ;   ;;       ;        ;    ;   ;;  ;   ;
+  ;     ;;;   ;    ;   ;;       ;        ;    ;   ;;  ;   ;
+  ;       ;   ;    ;   ;;       ;        ;    ;   ;;   ;;;
+  ;   ;   ;;  ;;  ;    ;;       ;        ;    ;   ;;  ;
+  ;    ;;;;    ;;;;   ;;;;      ;;;;   ;;;;;  ;   ;;   ;;;;
+  ;                                                        ;
+  ;                                                   ;    ;
+  ;                                                    ;;;;
+  ;
+
+  (let ((ascending-choice-list
          (list (vector 'ascend
                        (N_ "Ascending")
                        (N_ "Smallest to largest, earliest to latest."))
@@ -500,7 +501,7 @@ tags within description, notes or memo. ")
         (prime-sortkey 'account-name)
         (prime-sortkey-subtotal-true #t)
         (sec-sortkey 'register-order)
-        (sec-sortkey-subtotal-true #f)       
+        (sec-sortkey-subtotal-true #f)
         (key-choice-list (map
                           (lambda (sortpair)
                             (vector
@@ -551,6 +552,11 @@ tags within description, notes or memo. ")
              (and sec-sortkey-subtotal-enabled sec-sortkey-subtotal-true)))
 
         (gnc-option-db-set-option-selectable-by-name
+         options pagename-sorting optname-show-account-description
+         (or (and prime-sortkey-subtotal-enabled prime-sortkey-subtotal-true)
+             (and sec-sortkey-subtotal-enabled sec-sortkey-subtotal-true)))
+
+        (gnc-option-db-set-option-selectable-by-name
          options pagename-sorting optname-prime-date-subtotal
          prime-date-sortingtype-enabled)
 
@@ -568,21 +574,28 @@ tags within description, notes or memo. ")
       (lambda (x)
         (set! prime-sortkey x)
         (apply-selectable-by-name-sorting-options))))
-    
+
     (gnc:register-trep-option
      (gnc:make-simple-boolean-option
       pagename-sorting optname-full-account-name
       "j1"
-      (N_ "Show the full account name for subtotals and subtitles?")
+      (N_ "Show the full account name for subtotals and subheadings")
       #f))
-    
+
     (gnc:register-trep-option
      (gnc:make-simple-boolean-option
       pagename-sorting optname-show-account-code
       "j2"
-      (N_ "Show the account code for subtotals and subtitles?")
+      (N_ "Show the account code for subtotals and subheadings?")
       #f))
-    
+
+    (gnc:register-trep-option
+     (gnc:make-simple-boolean-option
+      pagename-sorting optname-show-account-description
+      "j3"
+      (N_ "Show the account description for subheadings?")
+      #f))
+
     (gnc:register-trep-option
      (gnc:make-complex-boolean-option
       pagename-sorting optname-prime-subtotal
@@ -599,14 +612,14 @@ tags within description, notes or memo. ")
       "e2" (N_ "Do a date subtotal.")
       'monthly
       date-subtotal-choice-list))
-    
+
     (gnc:register-trep-option
      (gnc:make-multichoice-option
       pagename-sorting optname-prime-sortorder
       "e" (N_ "Order of primary sorting.")
       'ascend
       ascending-choice-list))
-    
+
     ;; Secondary sorting criterion
     (gnc:register-trep-option
      (gnc:make-multichoice-callback-option
@@ -635,33 +648,33 @@ tags within description, notes or memo. ")
       "i2" (N_ "Do a date subtotal.")
       'monthly
       date-subtotal-choice-list))
-    
+
     (gnc:register-trep-option
      (gnc:make-multichoice-option
       pagename-sorting optname-sec-sortorder
       "i" (N_ "Order of Secondary sorting.")
       'ascend
       ascending-choice-list)))
-  
+
   ;; Display options
-  
-  ;                                                          
-  ;                                                          
-  ;                                                          
-  ;       ;;    ;;                    ;;;                    
-  ;       ;;    ;;                      ;                    
-  ;       ;;                            ;                    
-  ;    ;;;;;   ;;;     ;;;;   ; ;;;     ;     ;;;;    ;    ; 
-  ;   ;;  ;;     ;    ;;  ;   ;;  ;;    ;         ;   ;   ;  
-  ;   ;   ;;     ;    ;;      ;    ;    ;         ;    ;  ;  
-  ;   ;   ;;     ;      ;;;   ;    ;    ;      ;;;;    ;  ;  
-  ;   ;   ;;     ;        ;   ;    ;    ;     ;   ;    ; ;   
-  ;   ;;  ;;     ;    ;   ;;  ;;  ;     ;     ;   ;     ;;   
-  ;    ;;;;;   ;;;;;   ;;;;   ; ;;;     ;;;;   ;;;;;    ;;   
-  ;                           ;                         ;    
-  ;                           ;                         ;    
-  ;                           ;                       ;;     
-  ;                                                          
+
+  ;
+  ;
+  ;
+  ;       ;;    ;;                    ;;;
+  ;       ;;    ;;                      ;
+  ;       ;;                            ;
+  ;    ;;;;;   ;;;     ;;;;   ; ;;;     ;     ;;;;    ;    ;
+  ;   ;;  ;;     ;    ;;  ;   ;;  ;;    ;         ;   ;   ;
+  ;   ;   ;;     ;    ;;      ;    ;    ;         ;    ;  ;
+  ;   ;   ;;     ;      ;;;   ;    ;    ;      ;;;;    ;  ;
+  ;   ;   ;;     ;        ;   ;    ;    ;     ;   ;    ; ;
+  ;   ;;  ;;     ;    ;   ;;  ;;  ;     ;     ;   ;     ;;
+  ;    ;;;;;   ;;;;;   ;;;;   ; ;;;     ;;;;   ;;;;;    ;;
+  ;                           ;                         ;
+  ;                           ;                         ;
+  ;                           ;                       ;;
+  ;
 
   (let ((disp-memo? #t)
         (disp-accname? #t)
@@ -772,13 +785,13 @@ tags within description, notes or memo. ")
     (gnc:register-trep-option
      (gnc:make-multichoice-option
       gnc:pagename-display (N_ "Amount")
-      "m" (N_ "Display the amount?")  
+      "m" (N_ "Display the amount?")
       'single
       (list
        (vector 'none   (N_ "None") (N_ "No amount display."))
        (vector 'single (N_ "Single") (N_ "Single Column Display."))
        (vector 'double (N_ "Double") (N_ "Two Column Display.")))))
-  
+
     (gnc:register-trep-option
      (gnc:make-multichoice-option
       gnc:pagename-display (N_ "Sign Reverses")
@@ -800,23 +813,23 @@ Credit Card, and Income accounts."))))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;
 ;; Here comes the big function that builds the whole table.
-;                                                                                                                                  
-;                                                                                                                                  
-;                                                                                                                                  
-;                                                                                                                                  
-;   ;;  ;;    ;;    ;;   ;   ;;;;;           ;;;;    ;;;;    ;      ;;;;;   ;;;;;;          ;;;;;;    ;;    ;;;;;    ;       ;;;;; 
-;   ;;  ;;    ;;    ;;  ;    ;              ;    ;   ;   ;   ;        ;       ;               ;       ;;    ;   ;    ;       ;     
-;   ;;  ;;   ; ;    ;; ;     ;              ;        ;   ;   ;        ;       ;               ;      ; ;    ;   ;;   ;       ;     
-;   ;; ; ;   ;  ;   ;;;      ;              ;;       ;   ;   ;        ;       ;               ;      ;  ;   ;   ;    ;       ;     
-;   ; ;; ;   ;  ;   ;;;      ;;;;   ;;;;;;    ;;;    ;   ;   ;        ;       ;     ;;;;;;    ;      ;  ;   ;;;;     ;       ;;;;  
-;   ; ;; ;  ;;  ;   ;; ;     ;                  ;;   ;;;;    ;        ;       ;               ;     ;;  ;   ;   ;;   ;       ;     
-;   ; ;; ;  ;;;;;;  ;; ;;    ;                   ;   ;       ;        ;       ;               ;     ;;;;;;  ;    ;   ;       ;     
-;  ;;    ;  ;    ;  ;;  ;    ;              ;   ;;   ;       ;        ;       ;               ;     ;    ;  ;    ;   ;       ;     
-;  ;     ; ;;    ;; ;;   ;;  ;;;;;          ;;;;;    ;       ;;;;;  ;;;;;     ;               ;    ;;    ;; ;;;;;    ;;;;;   ;;;;; 
-;                                                                                                                                  
-;                                                                                                                                  
-;                                                                                                                                  
-;                                                                                                                                  
+;
+;
+;
+;
+;   ;;  ;;    ;;    ;;   ;   ;;;;;           ;;;;    ;;;;    ;      ;;;;;   ;;;;;;          ;;;;;;    ;;    ;;;;;    ;       ;;;;;
+;   ;;  ;;    ;;    ;;  ;    ;              ;    ;   ;   ;   ;        ;       ;               ;       ;;    ;   ;    ;       ;
+;   ;;  ;;   ; ;    ;; ;     ;              ;        ;   ;   ;        ;       ;               ;      ; ;    ;   ;;   ;       ;
+;   ;; ; ;   ;  ;   ;;;      ;              ;;       ;   ;   ;        ;       ;               ;      ;  ;   ;   ;    ;       ;
+;   ; ;; ;   ;  ;   ;;;      ;;;;   ;;;;;;    ;;;    ;   ;   ;        ;       ;     ;;;;;;    ;      ;  ;   ;;;;     ;       ;;;;
+;   ; ;; ;  ;;  ;   ;; ;     ;                  ;;   ;;;;    ;        ;       ;               ;     ;;  ;   ;   ;;   ;       ;
+;   ; ;; ;  ;;;;;;  ;; ;;    ;                   ;   ;       ;        ;       ;               ;     ;;;;;;  ;    ;   ;       ;
+;  ;;    ;  ;    ;  ;;  ;    ;              ;   ;;   ;       ;        ;       ;               ;     ;    ;  ;    ;   ;       ;
+;  ;     ; ;;    ;; ;;   ;;  ;;;;;          ;;;;;    ;       ;;;;;  ;;;;;     ;               ;    ;;    ;; ;;;;;    ;;;;;   ;;;;;
+;
+;
+;
+;
 
 (define (make-split-table splits options
                           primary-subtotal-comparator
@@ -852,6 +865,7 @@ Credit Card, and Income accounts."))))))
                                               (opt-val gnc:pagename-display (N_ "Use Full Other Account Name"))))
           (cons 'sort-account-code (opt-val pagename-sorting (N_ "Show Account Code")))
           (cons 'sort-account-full-name (opt-val pagename-sorting (N_ "Show Full Account Name")))
+          (cons 'sort-account-description (opt-val pagename-sorting (N_ "Show Account Description")))
           (cons 'notes (opt-val gnc:pagename-display (N_ "Notes")))))
 
   (define (column-uses? param columns-used)
@@ -922,20 +936,20 @@ Credit Card, and Income accounts."))))))
     (define (add-subtotal-row string collector style)
       (let ((currency-totals (collector 'format gnc:make-gnc-monetary #f)))
         (gnc:html-table-append-row/markup!
-         table style 
+         table style
          (if export?
              (append! (cons (gnc:make-html-table-cell/markup "total-label-cell" string)
                             (gnc:html-make-empty-cells (- width 2)))
-                      (list (gnc:make-html-table-cell/markup 
+                      (list (gnc:make-html-table-cell/markup
                              "total-number-cell"
                              (car currency-totals))))
              (list (gnc:make-html-table-cell/size/markup 1 (- width 1) "total-label-cell"
                                                          string)
-                   (gnc:make-html-table-cell/markup 
+                   (gnc:make-html-table-cell/markup
                     "total-number-cell"
                     (car currency-totals)))))
         (for-each (lambda (currency)
-                    (gnc:html-table-append-row/markup! 
+                    (gnc:html-table-append-row/markup!
                      table style
                      (append!
                       (if export?
@@ -946,39 +960,41 @@ Credit Card, and Income accounts."))))))
                   (cdr currency-totals))))
 
     (define (total-string str) (string-append (_ "Total For ") str))
-    ;             
-    ;                                                                          
-    ;                               ;;                                         
-    ;                               ;;                                         
-    ;                               ;;                                         
-    ;   ;; ;;;   ;;;;   ; ;;;    ;;;;;   ;;;;   ;; ;;;   ;;;;   ;; ;;;   ;;;;  
-    ;    ;;  ;  ;;  ;   ;;  ;   ;;  ;;  ;;  ;    ;;  ;  ;;  ;    ;;  ;  ;;  ;  
-    ;    ;;     ;    ;  ;   ;;  ;   ;;  ;    ;   ;;     ;    ;   ;;     ;;     
-    ;    ;;     ;;;;;;  ;   ;;  ;   ;;  ;;;;;;   ;;     ;;;;;;   ;;       ;;;  
-    ;    ;;     ;       ;   ;;  ;   ;;  ;        ;;     ;        ;;         ;  
-    ;    ;;     ;;      ;   ;;  ;;  ;;  ;;       ;;     ;;       ;;     ;   ;; 
-    ;   ;;;;     ;;;;;  ;   ;;   ;;;;;   ;;;;;  ;;;;     ;;;;;  ;;;;     ;;;;  
-    ;                                                                          
-    ;                                                                          
-    ;                                                                          
-    ;                                                                          
-            
+    ;
+    ;
+    ;                               ;;
+    ;                               ;;
+    ;                               ;;
+    ;   ;; ;;;   ;;;;   ; ;;;    ;;;;;   ;;;;   ;; ;;;   ;;;;   ;; ;;;   ;;;;
+    ;    ;;  ;  ;;  ;   ;;  ;   ;;  ;;  ;;  ;    ;;  ;  ;;  ;    ;;  ;  ;;  ;
+    ;    ;;     ;    ;  ;   ;;  ;   ;;  ;    ;   ;;     ;    ;   ;;     ;;
+    ;    ;;     ;;;;;;  ;   ;;  ;   ;;  ;;;;;;   ;;     ;;;;;;   ;;       ;;;
+    ;    ;;     ;       ;   ;;  ;   ;;  ;        ;;     ;        ;;         ;
+    ;    ;;     ;;      ;   ;;  ;;  ;;  ;;       ;;     ;;       ;;     ;   ;;
+    ;   ;;;;     ;;;;;  ;   ;;   ;;;;;   ;;;;;  ;;;;     ;;;;;  ;;;;     ;;;;
+    ;
+    ;
+    ;
+    ;
+
     ;; display an account name depending on the options the user has set
-    (define (account-namestring account show-account-code? show-account-name? show-account-full-name?)
+    (define (account-namestring account code? name? full-name?)
       ;;# on multi-line splits we can get an empty ('()) account
       (if (null? account)
           (_ "Split Transaction")
-          (string-append 
-           (if show-account-code?
-               (string-append (xaccAccountGetCode account) " ")
-               "")
-           (if show-account-name?
-               (if show-account-full-name?
-                   (gnc-account-get-full-name account)
-                   (xaccAccountGetName account))
-               ""))))
+          (string-join
+           (append
+            (if code?
+                (list (xaccAccountGetCode account))
+                '())
+            (if name?
+                (if full-name?
+                    (list (gnc-account-get-full-name account))
+                    (list (xaccAccountGetName account)))
+                '()))
+           " ")))
 
-    (define (render-date renderer-key split)      
+    (define (render-date renderer-key split)
       ((case renderer-key
          ((week) gnc:date-get-week-year-string)
          ((month) gnc:date-get-month-year-string)
@@ -995,12 +1011,15 @@ Credit Card, and Income accounts."))))))
              (name (account-namestring account
                                        (column-uses? 'sort-account-code      used-columns)
                                        #t
-                                       (column-uses? 'sort-account-full-name used-columns))))
+                                       (column-uses? 'sort-account-full-name used-columns)))
+             (description (if (column-uses? 'sort-account-description used-columns)
+                              (string-append ": " (xaccAccountGetDescription account))
+                              "")))
         (if (and anchor? (not (null? account))) ;html anchor for 2-split transactions only
             (gnc:make-html-text
              (gnc:html-markup-anchor (gnc:account-anchor-text account) name))
-            name)))
-    
+            (string-append name description))))
+
     (define (render-summary split renderer-key anchor?)
       (case renderer-key
         ((week month quarter year) (render-date renderer-key split))
@@ -1009,25 +1028,25 @@ Credit Card, and Income accounts."))))))
 
     (define (render-grand-total)
       (_ "Grand Total"))
-    
+
     ;
-    ;                                                                                                          
-    ;                                                                                                          
-    ;                                                                                                          
-    ;               ;;      ;;                          ;;;       ;;                                           
-    ;               ;;      ;;                            ;       ;;      ;                                    
-    ;               ;;      ;;                            ;               ;                                    
+    ;
+    ;
+    ;
+    ;               ;;      ;;                          ;;;       ;;
+    ;               ;;      ;;                            ;       ;;      ;
+    ;               ;;      ;;                            ;               ;
     ;   ;;;;     ;;;;;   ;;;;;           ;;;;   ; ;;;     ;      ;;;    ;;;;;           ;; ;;;   ;;;;  ;     ;;
-    ;       ;   ;;  ;;  ;;  ;;          ;;  ;   ;;  ;;    ;        ;      ;              ;;  ;  ;;  ;  ;; ;; ; 
-    ;       ;   ;   ;;  ;   ;;  ;;;;;;  ;;      ;    ;    ;        ;      ;     ;;;;;;   ;;     ;    ;  ; ;; ; 
-    ;    ;;;;   ;   ;;  ;   ;;            ;;;   ;    ;    ;        ;      ;              ;;     ;    ;  ; ;; ; 
-    ;   ;   ;   ;   ;;  ;   ;;              ;   ;    ;    ;        ;      ;              ;;     ;    ;  ; ;; ; 
-    ;   ;   ;   ;;  ;;  ;;  ;;          ;   ;;  ;;  ;     ;        ;      ;              ;;     ;;  ;   ;;  ;; 
-    ;    ;;;;;   ;;;;;   ;;;;;           ;;;;   ; ;;;     ;;;;   ;;;;;    ;;;;          ;;;;     ;;;;   ;;  ;  
-    ;                                           ;                                                              
-    ;                                           ;                                                              
-    ;                                           ;                                                              
-    ;                                                                                                          
+    ;       ;   ;;  ;;  ;;  ;;          ;;  ;   ;;  ;;    ;        ;      ;              ;;  ;  ;;  ;  ;; ;; ;
+    ;       ;   ;   ;;  ;   ;;  ;;;;;;  ;;      ;    ;    ;        ;      ;     ;;;;;;   ;;     ;    ;  ; ;; ;
+    ;    ;;;;   ;   ;;  ;   ;;            ;;;   ;    ;    ;        ;      ;              ;;     ;    ;  ; ;; ;
+    ;   ;   ;   ;   ;;  ;   ;;              ;   ;    ;    ;        ;      ;              ;;     ;    ;  ; ;; ;
+    ;   ;   ;   ;;  ;;  ;;  ;;          ;   ;;  ;;  ;     ;        ;      ;              ;;     ;;  ;   ;;  ;;
+    ;    ;;;;;   ;;;;;   ;;;;;           ;;;;   ; ;;;     ;;;;   ;;;;;    ;;;;          ;;;;     ;;;;   ;;  ;
+    ;                                           ;
+    ;                                           ;
+    ;                                           ;
+    ;
 
     (define (add-split-row split row-style transaction-row?)
       (let* ((row-contents '())
@@ -1049,9 +1068,9 @@ Credit Card, and Income accounts."))))))
                                         report-currency
                                         (timespecCanonicalDayTime trans-date)))
              (split-value (gnc:exchange-by-pricedb-nearest
-                           (gnc:make-gnc-monetary 
+                           (gnc:make-gnc-monetary
                             currency
-                            (if (member account-type account-types-to-reverse) 
+                            (if (member account-type account-types-to-reverse)
                                 (gnc-numeric-neg damount)
                                 damount))
                            report-currency
@@ -1059,7 +1078,7 @@ Credit Card, and Income accounts."))))))
                            ;; on the same day.  Otherwise it uses midnight which will
                            ;; likely match a price on the previous day
                            (timespecCanonicalDayTime trans-date))))
-        
+
         (if (column-uses? 'date used-columns)
             (addto! row-contents
                     (if transaction-row?
@@ -1067,7 +1086,7 @@ Credit Card, and Income accounts."))))))
                          "date-cell"
                          (gnc-print-date trans-date))
                         "")))
-    
+
         (if (column-uses? 'reconciled-date used-columns)
             (addto! row-contents
                     (gnc:make-html-table-cell/markup
@@ -1103,37 +1122,37 @@ Credit Card, and Income accounts."))))))
                          "text-cell"
                          (xaccTransGetDescription parent))
                         "")))
-    
+
         (if (column-uses? 'memo used-columns)
             (let ((memo (xaccSplitGetMemo split)))
               (if (and (string-null? memo) (column-uses? 'notes used-columns))
                   (addto! row-contents (xaccTransGetNotes parent))
                   (addto! row-contents memo))))
-    
+
         (if (or (column-uses? 'account-name used-columns) (column-uses? 'account-code used-columns))
             (addto! row-contents (account-namestring account
                                                      (column-uses? 'account-code      used-columns)
                                                      (column-uses? 'account-name      used-columns)
                                                      (column-uses? 'account-full-name used-columns))))
-    
+
         (if (or (column-uses? 'other-account-name used-columns) (column-uses? 'other-account-code used-columns))
             (addto! row-contents (account-namestring (xaccSplitGetAccount (xaccSplitGetOtherSplit split))
                                                      (column-uses? 'other-account-code      used-columns)
                                                      (column-uses? 'other-account-name      used-columns)
                                                      (column-uses? 'other-account-full-name used-columns))))
-    
+
         (if (column-uses? 'shares used-columns)
             (addto! row-contents (xaccSplitGetAmount split)))
-    
+
         (if (column-uses? 'price used-columns)
             (addto! row-contents  (gnc:make-gnc-monetary (xaccTransGetCurrency parent)
                                                          (xaccSplitGetSharePrice split))))
-    
+
         (if (column-uses? 'amount-single used-columns)
             (addto! row-contents
                     (gnc:make-html-table-cell/markup
                      "number-cell" (gnc:html-transaction-anchor parent split-value))))
-    
+
         (if (column-uses? 'amount-double used-columns)
             ;; I'm now using the split-value-not-reversed. Internal value representation
             ;; is positive = debit amount
@@ -1152,7 +1171,7 @@ Credit Card, and Income accounts."))))))
                           (gnc:make-html-table-cell/markup
                            "number-cell" (gnc:html-transaction-anchor
                                           parent (gnc:monetary-neg split-value-not-reversed)))))))
-    
+
         (if (column-uses? 'running-balance used-columns)
             (begin
               ;(gnc:debug "split is " split)
@@ -1162,106 +1181,106 @@ Credit Card, and Income accounts."))))))
                        "number-cell"
                        (gnc:make-gnc-monetary currency
                                               (xaccSplitGetBalance split))))))
-    
+
         (gnc:html-table-append-row/markup! table row-style (reverse row-contents))
 
-        split-value))
+        split-value-not-reversed))
 
 
 
 
-    ;                                                                                                                  
-    ;                                                                  ;                                  ;;;          
-    ;                                                                  ;       ;             ;              ;          
-    ;                                                                  ;       ;             ;              ;          
-    ;   ;; ;;   ;;;  ;     ;  ;;;;        ;     ;         ;;;;  ;   ;  ; ;;   ;;;;;   ;;;   ;;;;;  ;;;;     ;     ;;;; 
-    ;    ;; ;  ;   ; ;  ;  ; ;   ;        ;  ;  ;        ;   ;  ;   ;  ;;  ;   ;     ;   ;   ;         ;    ;    ;   ; 
-    ;    ;     ;   ;  ; ;; ; ;;     ;;;;;  ; ;; ; ;;;;;  ;;     ;   ;  ;   ;   ;     ;   ;   ;         ;    ;    ;;    
-    ;    ;     ;   ;  ;; ;;    ;;          ;; ;;           ;;   ;   ;  ;   ;   ;     ;   ;   ;      ;;;;    ;      ;;  
-    ;    ;     ;   ;  ;; ;;      ;         ;; ;;             ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;        ; 
-    ;    ;     ;   ;  ;; ;;  ;   ;         ;; ;;         ;   ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;    ;   ; 
-    ;   ;;;;    ;;;   ;; ;;  ;;;;          ;; ;;         ;;;;    ;;;;  ;;;;     ;;;   ;;;     ;;;  ;;;;;    ;;;  ;;;;  
-    ;                                                                                                                  
-    ;                                                                                                                  
-    ;                                                                                                                  
-    ;                                                                                                                  
+    ;
+    ;                                                                  ;                                  ;;;
+    ;                                                                  ;       ;             ;              ;
+    ;                                                                  ;       ;             ;              ;
+    ;   ;; ;;   ;;;  ;     ;  ;;;;        ;     ;         ;;;;  ;   ;  ; ;;   ;;;;;   ;;;   ;;;;;  ;;;;     ;     ;;;;
+    ;    ;; ;  ;   ; ;  ;  ; ;   ;        ;  ;  ;        ;   ;  ;   ;  ;;  ;   ;     ;   ;   ;         ;    ;    ;   ;
+    ;    ;     ;   ;  ; ;; ; ;;     ;;;;;  ; ;; ; ;;;;;  ;;     ;   ;  ;   ;   ;     ;   ;   ;         ;    ;    ;;
+    ;    ;     ;   ;  ;; ;;    ;;          ;; ;;           ;;   ;   ;  ;   ;   ;     ;   ;   ;      ;;;;    ;      ;;
+    ;    ;     ;   ;  ;; ;;      ;         ;; ;;             ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;        ;
+    ;    ;     ;   ;  ;; ;;  ;   ;         ;; ;;         ;   ;  ;   ;  ;   ;   ;     ;   ;   ;     ;   ;    ;    ;   ;
+    ;   ;;;;    ;;;   ;; ;;  ;;;;          ;; ;;         ;;;;    ;;;;  ;;;;     ;;;   ;;;     ;;;  ;;;;;    ;;;  ;;;;
+    ;
+    ;
+    ;
+    ;
 
-    
-    (define (do-rows-with-subtotals splits 
+
+    (define (do-rows-with-subtotals splits
                                     odd-row?
-                                    primary-subtotal-collector 
-                                    secondary-subtotal-collector 
+                                    primary-subtotal-collector
+                                    secondary-subtotal-collector
                                     total-collector)
 
       (gnc:report-percent-done (* 100 (/ work-done work-to-do)))
 
       (set! work-done (+ 1 work-done))
-      
+
       (if (null? splits)
-          
-          (begin            
+
+          (begin
             (gnc:html-table-append-row/markup!
              table def:grand-total-style
              (list
               (gnc:make-html-table-cell/size
                1 width (gnc:make-html-text (gnc:html-markup-hr)))))
-            
+
             (if (opt-val gnc:pagename-display "Totals")
                 (add-subtotal-row (render-grand-total) total-collector def:grand-total-style)))
-          
+
           (let* ((current (car splits))
                  (rest (cdr splits))
                  (next (if (null? rest) #f (car rest)))
-                 (split-value (add-split-row 
-                               current 
+                 (split-value (add-split-row
+                               current
                                (if is-multiline? def:normal-row-style
                                    (if odd-row?
-                                       def:normal-row-style 
+                                       def:normal-row-style
                                        def:alternate-row-style))
                                #t)))
-            
-            (if is-multiline?                
+
+            (if is-multiline?
                 (for-each
                  (lambda (othersplits)
                    (add-split-row othersplits def:alternate-row-style #f))
                  (delete current (xaccTransGetSplitList (xaccSplitGetParent current)))))
-            
+
             (primary-subtotal-collector
              'add (gnc:gnc-monetary-commodity split-value) (gnc:gnc-monetary-amount split-value))
 
             (secondary-subtotal-collector
-             'add (gnc:gnc-monetary-commodity split-value) (gnc:gnc-monetary-amount split-value))            
+             'add (gnc:gnc-monetary-commodity split-value) (gnc:gnc-monetary-amount split-value))
 
             (total-collector
              'add (gnc:gnc-monetary-commodity split-value) (gnc:gnc-monetary-amount split-value))
-            
+
             (if (and primary-subtotal-comparator
                      (or (not next)
                          (and next
                               (not (equal? (primary-subtotal-comparator current)
                                            (primary-subtotal-comparator next))))))
-                
-                (begin                   
-                  (if secondary-subtotal-comparator                      
-                      (begin                        
+
+                (begin
+                  (if secondary-subtotal-comparator
+                      (begin
                         (add-subtotal-row (total-string
                                            (render-summary current secondary-renderer-key #f))
-                                           secondary-subtotal-collector
-                                           def:secondary-subtotal-style)
-                        (secondary-subtotal-collector 'reset #f #f)))                  
+                                          secondary-subtotal-collector
+                                          def:secondary-subtotal-style)
+                        (secondary-subtotal-collector 'reset #f #f)))
                   (add-subtotal-row (total-string
                                      (render-summary current primary-renderer-key #f))
-                                     primary-subtotal-collector
-                                     def:primary-subtotal-style)                  
-                  (primary-subtotal-collector 'reset #f #f)                  
-                  (if next                      
-                      (begin                         
+                                    primary-subtotal-collector
+                                    def:primary-subtotal-style)
+                  (primary-subtotal-collector 'reset #f #f)
+                  (if next
+                      (begin
                         (add-subheading (render-summary next primary-renderer-key #t)
-                                        def:primary-subtotal-style)                        
+                                        def:primary-subtotal-style)
                         (if secondary-subtotal-comparator
                             (add-subheading (render-summary next secondary-renderer-key #t)
                                             def:secondary-subtotal-style)))))
-                
+
                 (if (and secondary-subtotal-comparator
                          (or (not next)
                              (and next
@@ -1269,56 +1288,56 @@ Credit Card, and Income accounts."))))))
                                                (secondary-subtotal-comparator next))))))
                     (begin (add-subtotal-row (total-string
                                               (render-summary current secondary-renderer-key #f))
-                                              secondary-subtotal-collector
-                                             def:secondary-subtotal-style)                           
-                           (secondary-subtotal-collector 'reset #f #f)                           
+                                             secondary-subtotal-collector
+                                             def:secondary-subtotal-style)
+                           (secondary-subtotal-collector 'reset #f #f)
                            (if next
                                (add-subheading (render-summary next secondary-renderer-key #t)
                                                def:secondary-subtotal-style)))))
-            
-            (do-rows-with-subtotals rest 
+
+            (do-rows-with-subtotals rest
                                     (not odd-row?)
-                                    primary-subtotal-collector 
-                                    secondary-subtotal-collector 
+                                    primary-subtotal-collector
+                                    secondary-subtotal-collector
                                     total-collector))))
-    
+
     (gnc:html-table-set-col-headers! table headings)
-    
-    (if primary-renderer-key 
+
+    (if primary-renderer-key
         (add-subheading (render-summary (car splits) primary-renderer-key #t)
                         def:primary-subtotal-style))
-    
+
     (if secondary-renderer-key
         (add-subheading (render-summary (car splits) secondary-renderer-key #t)
                         def:secondary-subtotal-style))
-    
+
     (do-rows-with-subtotals splits #t
                             (gnc:make-commodity-collector)
                             (gnc:make-commodity-collector)
                             (gnc:make-commodity-collector))
-    
+
     table))
 
 ;; ;;;;;;;;;;;;;;;;;;;;
 ;; Here comes the renderer function for this report.
 
-;                                                                                                          
-;                                                                                                          
-;                                                                                                          
-;                                                                                                          
-;   ;;;;;;  ;;;;;    ;;;;;   ;;;;           ;;;;;    ;;;;;  ;;   ;  ;;;;     ;;;;;  ;;;;;    ;;;;;  ;;;;;  
-;     ;     ;    ;   ;       ;   ;          ;    ;   ;      ;;   ;  ;   ;;   ;      ;    ;   ;      ;    ; 
-;     ;     ;    ;   ;       ;   ;          ;    ;   ;      ; ;  ;  ;    ;   ;      ;    ;   ;      ;    ; 
-;     ;     ;   ;;   ;       ;   ;          ;   ;;   ;      ; ;  ;  ;    ;   ;      ;   ;;   ;      ;   ;; 
-;     ;     ;;;;;    ;;;;    ;   ;  ;;;;;;  ;;;;;    ;;;;   ; ;  ;  ;    ;   ;;;;   ;;;;;    ;;;;   ;;;;;  
-;     ;     ;  ;     ;       ;;;;           ;  ;     ;      ;  ; ;  ;    ;   ;      ;  ;     ;      ;  ;   
-;     ;     ;   ;    ;       ;              ;   ;    ;      ;  ; ;  ;    ;   ;      ;   ;    ;      ;   ;  
-;     ;     ;   ;;   ;       ;              ;   ;;   ;      ;   ;;  ;   ;    ;      ;   ;;   ;      ;   ;; 
-;     ;     ;    ;   ;;;;;   ;              ;    ;   ;;;;;  ;   ;;  ;;;;     ;;;;;  ;    ;   ;;;;;  ;    ; 
-;                                                                                                          
-;                                                                                                          
-;                                                                                                          
-;                                                                                                          
+;
+;
+;
+;
+;   ;;;;;;  ;;;;;    ;;;;;   ;;;;           ;;;;;    ;;;;;  ;;   ;  ;;;;     ;;;;;  ;;;;;    ;;;;;  ;;;;;
+;     ;     ;    ;   ;       ;   ;          ;    ;   ;      ;;   ;  ;   ;;   ;      ;    ;   ;      ;    ;
+;     ;     ;    ;   ;       ;   ;          ;    ;   ;      ; ;  ;  ;    ;   ;      ;    ;   ;      ;    ;
+;     ;     ;   ;;   ;       ;   ;          ;   ;;   ;      ; ;  ;  ;    ;   ;      ;   ;;   ;      ;   ;;
+;     ;     ;;;;;    ;;;;    ;   ;  ;;;;;;  ;;;;;    ;;;;   ; ;  ;  ;    ;   ;;;;   ;;;;;    ;;;;   ;;;;;
+;     ;     ;  ;     ;       ;;;;           ;  ;     ;      ;  ; ;  ;    ;   ;      ;  ;     ;      ;  ;
+;     ;     ;   ;    ;       ;              ;   ;    ;      ;  ; ;  ;    ;   ;      ;   ;    ;      ;   ;
+;     ;     ;   ;;   ;       ;              ;   ;;   ;      ;   ;;  ;   ;    ;      ;   ;;   ;      ;   ;;
+;     ;     ;    ;   ;;;;;   ;              ;    ;   ;;;;;  ;   ;;  ;;;;     ;;;;;  ;    ;   ;;;;;  ;    ;
+;
+;
+;
+;
 
 (define (trep-renderer report-obj)
   (define options (gnc:report-options report-obj))
@@ -1336,10 +1355,10 @@ Credit Card, and Income accounts."))))))
           ;; subtotalling enabled at all, 2. check whether the
           ;; enable-subtotal boolean option is #t, 3. look up the
           ;; appropriate funcs in the assoc-list.
-          (and (member sortkey SUBTOTAL-ENABLED) 
+          (and (member sortkey SUBTOTAL-ENABLED)
                (and (opt-val pagename-sorting name-subtotal)
                     (sortkey-get-info sortkey info))))))
-  
+
   (define (is-filter-member split account-list)
     (let* ((txn (xaccSplitGetParent split))
            (splitcount (xaccTransCountSplits txn))
@@ -1359,7 +1378,7 @@ Credit Card, and Income accounts."))))))
         (else #f))))
 
   (gnc:report-starting reportname)
-  
+
   (let* ((document (gnc:make-html-document))
          (account-matcher (opt-val pagename-filter optname-account-matcher))
          (account-matcher-regexp (if (opt-val pagename-filter optname-account-matcher-regex)
@@ -1400,10 +1419,10 @@ Credit Card, and Income accounts."))))))
     (if (or (null? c_account_1) (and-map not c_account_1))
 
         (if (null? c_account_0)
-            
+
             ;; error condition: no accounts specified
             (gnc:html-document-add-object!
-             document 
+             document
              (gnc:html-make-no-account-warning report-title (gnc:report-id report-obj)))
 
             ;; error condition: accounts were specified but none matcher string/regex
@@ -1414,7 +1433,7 @@ Credit Card, and Income accounts."))))))
               (gnc:html-markup-p NO-MATCHING-ACCT-TEXT))))
 
         (begin
-          
+
           (qof-query-set-book query (gnc-get-current-book))
           (xaccQueryAddAccountMatch query c_account_1 QOF-GUID-MATCH-ANY QOF-QUERY-AND)
           (xaccQueryAddDateMatchTS query #t begindate #t enddate QOF-QUERY-AND)
@@ -1431,12 +1450,12 @@ Credit Card, and Income accounts."))))))
             ((void-only)     (gnc:query-set-match-voids-only! query (gnc-get-current-book)))
             (else #f))
           (set! splits (qof-query-run query))
-          
+
           ; this qof-query destroyer was formerly after
           ; (gnc:html-document-add-object! document table) --
           ; move it here
           (qof-query-destroy query)
-          
+
           ; Combined Filter:
           ; - include/exclude splits to/from selected accounts
           ; - substring/regex matcher for Transaction Description/Notes/Memo
@@ -1459,39 +1478,39 @@ Credit Card, and Income accounts."))))))
                         splits))
 
           (if (null? splits)
-              
+
               ;; error condition: no splits found
               (gnc:html-document-add-object!
                document
                (gnc:make-html-text
                 (gnc:html-markup-h2 NO-MATCHING-TRANS-HEADER)
                 (gnc:html-markup-p NO-MATCHING-TRANS-TEXT)))
-              
+
               (let ((table (make-split-table
                             splits options
-                            (subtotal-get-info optname-prime-sortkey 
+                            (subtotal-get-info optname-prime-sortkey
                                                optname-prime-subtotal
                                                optname-prime-date-subtotal
                                                'split-sortvalue)
-                            (subtotal-get-info optname-sec-sortkey 
+                            (subtotal-get-info optname-sec-sortkey
                                                optname-sec-subtotal
                                                optname-sec-date-subtotal
                                                'split-sortvalue)
-                            (subtotal-get-info optname-prime-sortkey 
+                            (subtotal-get-info optname-prime-sortkey
                                                optname-prime-subtotal
                                                optname-prime-date-subtotal
                                                'renderer-key)
-                            (subtotal-get-info optname-sec-sortkey 
+                            (subtotal-get-info optname-sec-sortkey
                                                optname-sec-subtotal
                                                optname-sec-date-subtotal
                                                'renderer-key))))
-                
+
                 (gnc:html-document-set-title! document report-title)
 
-                (gnc:html-document-add-object! 
+                (gnc:html-document-add-object!
                  document
                  (gnc:make-html-text
-                  (gnc:html-markup-h3 
+                  (gnc:html-markup-h3
                    (sprintf #f
                             (_ "From %s to %s")
                             (gnc-print-date begindate)
@@ -1500,7 +1519,7 @@ Credit Card, and Income accounts."))))))
                 (gnc:html-document-add-object! document table)))))
 
     (gnc:report-finished)
-    
+
     document))
 
 ;; Define the report.

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -982,17 +982,15 @@ Credit Card, and Income accounts."))))))
       ;;# on multi-line splits we can get an empty ('()) account
       (if (null? account)
           (_ "Split Transaction")
-          (string-join
-           (append
-            (if code?
-                (list (xaccAccountGetCode account))
-                '())
-            (if name?
-                (if full-name?
-                    (list (gnc-account-get-full-name account))
-                    (list (xaccAccountGetName account)))
-                '()))
-           " ")))
+          (string-append
+           (if show-account-code?
+               (string-append (xaccAccountGetCode account) " ")
+               "")
+           (if show-account-name?
+               (if show-account-full-name?
+                   (gnc-account-get-full-name account)
+                   (xaccAccountGetName account))
+               ""))))
 
     (define (render-date renderer-key split)
       ((case renderer-key

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -35,6 +35,7 @@
 (use-modules (gnucash main)) ;; FIXME: delete after we finish modularizing.
 (use-modules (srfi srfi-1))
 (use-modules (srfi srfi-13))
+(use-modules (ice-9 hash-table))
 (use-modules (ice-9 regex))
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
@@ -100,51 +101,14 @@ in the Options panel."))
 (define NO-MATCHING-ACCT-TEXT (N_ "No account were found that match the \
 options specified in the Options panels."))
 
+
+(define date-sorting-types (list 'date 'reconciled-date))
+
 ;; The option-values of the sorting key multichoice option, for
 ;; which a subtotal should be enabled.
-(define subtotal-enabled '(account-name
-                           account-code 
-                           corresponding-acc-name
-                           corresponding-acc-code))
+(define subtotal-enabled '(account-name corresponding-acc-name
+                           account-code corresponding-acc-code))
 
-(define (timepair-same-year tp-a tp-b)
-  (= (gnc:timepair-get-year tp-a)
-     (gnc:timepair-get-year tp-b)))
-
-(define (timepair-same-quarter tp-a tp-b)
-  (and (timepair-same-year tp-a tp-b) 
-       (= (gnc:timepair-get-quarter tp-a)
-          (gnc:timepair-get-quarter tp-b))))
-
-(define (timepair-same-month tp-a tp-b)
-  (and (timepair-same-year tp-a tp-b) 
-       (= (gnc:timepair-get-month tp-a)
-          (gnc:timepair-get-month tp-b))))
-
-(define (timepair-same-week tp-a tp-b)
-  (and (timepair-same-year tp-a tp-b)
-       (= (gnc:timepair-get-week tp-a)
-          (gnc:timepair-get-week tp-b))))
-
-(define (split-same-week? a b)
-  (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
-        (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
-    (timepair-same-week tp-a tp-b)))
-
-(define (split-same-month? a b)
-  (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
-        (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
-    (timepair-same-month tp-a tp-b)))
-
-(define (split-same-quarter? a b)
-  (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
-        (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
-    (timepair-same-quarter tp-a tp-b)))
-
-(define (split-same-year? a b)
-  (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
-        (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
-    (timepair-same-year tp-a tp-b)))
 
 (define (add-subheading-row data table width subheading-style)
   (let ((heading-cell (gnc:make-html-table-cell data)))
@@ -153,6 +117,25 @@ options specified in the Options panels."))
      table subheading-style
      (list heading-cell))))
 
+(define (column-uses? param columns-used) (hash-ref columns-used param))
+
+;             
+;                                                                          
+;                               ;;                                         
+;                               ;;                                         
+;                               ;;                                         
+;   ;; ;;;   ;;;;   ; ;;;    ;;;;;   ;;;;   ;; ;;;   ;;;;   ;; ;;;   ;;;;  
+;    ;;  ;  ;;  ;   ;;  ;   ;;  ;;  ;;  ;    ;;  ;  ;;  ;    ;;  ;  ;;  ;  
+;    ;;     ;    ;  ;   ;;  ;   ;;  ;    ;   ;;     ;    ;   ;;     ;;     
+;    ;;     ;;;;;;  ;   ;;  ;   ;;  ;;;;;;   ;;     ;;;;;;   ;;       ;;;  
+;    ;;     ;       ;   ;;  ;   ;;  ;        ;;     ;        ;;         ;  
+;    ;;     ;;      ;   ;;  ;;  ;;  ;;       ;;     ;;       ;;     ;   ;; 
+;   ;;;;     ;;;;;  ;   ;;   ;;;;;   ;;;;;  ;;;;     ;;;;;  ;;;;     ;;;;  
+;                                                                          
+;                                                                          
+;                                                                          
+;                                                                          
+            
 ;; display an account name depending on the options the user has set
 (define (account-namestring account show-account-code? show-account-name? show-account-full-name?)
   ;;# on multi-line splits we can get an empty ('()) account
@@ -171,6 +154,8 @@ options specified in the Options panels."))
                (xaccAccountGetName account))
            ""))))
 
+                                                   
+
 ;; render an account subheading - column-vector determines what is displayed
 (define (render-account-subheading
          split table width subheading-style column-vector)
@@ -179,9 +164,9 @@ options specified in the Options panels."))
                          (gnc:html-markup-anchor
                           (gnc:account-anchor-text account)
                           (account-namestring account
-                                              (used-sort-account-code      column-vector)
+                                              (column-uses? 'sort-account-code      column-vector)
                                               #t
-                                              (used-sort-account-full-name column-vector))))
+                                              (column-uses? 'sort-account-full-name column-vector))))
                         table width subheading-style)))
 
 (define (render-corresponding-account-subheading 
@@ -193,9 +178,9 @@ options specified in the Options panels."))
                               ""
                               (gnc:account-anchor-text account))
                           (account-namestring account
-                                              (used-sort-account-code      column-vector)
+                                              (column-uses? 'sort-account-code      column-vector)
                                               #t
-                                              (used-sort-account-full-name column-vector))))
+                                              (column-uses? 'sort-account-full-name column-vector))))
                         table width subheading-style)))
 
 (define (render-week-subheading split table width subheading-style column-vector)
@@ -261,9 +246,9 @@ options specified in the Options panels."))
          table width split total-collector subtotal-style column-vector export?)
   (add-subtotal-row table width 
                     (total-string (account-namestring (xaccSplitGetAccount split)
-                                                      (used-sort-account-code      column-vector)
+                                                      (column-uses? 'sort-account-code      column-vector)
                                                       #t
-                                                      (used-sort-account-full-name column-vector)))
+                                                      (column-uses? 'sort-account-full-name column-vector)))
                     total-collector subtotal-style export?))
 
 (define (render-corresponding-account-subtotal
@@ -271,9 +256,9 @@ options specified in the Options panels."))
   (add-subtotal-row table width
                     (total-string (account-namestring (xaccSplitGetAccount
                                                        (xaccSplitGetOtherSplit split))
-                                                      (used-sort-account-code      column-vector)
+                                                      (column-uses? 'sort-account-code      column-vector)
                                                       #t
-                                                      (used-sort-account-full-name column-vector)))
+                                                      (column-uses? 'sort-account-full-name column-vector)))
                     total-collector subtotal-style export?))
 
 (define (render-week-subtotal
@@ -314,7 +299,6 @@ options specified in the Options panels."))
   (add-subtotal-row table width
                     (_ "Grand Total")
                     total-collector def:grand-total-style export?))
-
 
 
 
@@ -368,95 +352,99 @@ options specified in the Options panels."))
                        ;; likely match a price on the previous day
                        (timespecCanonicalDayTime trans-date))))
     
-    (if (used-date column-vector)
+    (if (column-uses? 'date column-vector)
         (addto! row-contents
                 (if transaction-row?
-                    (gnc:make-html-table-cell/markup "date-cell"
-                                                     (gnc-print-date (gnc-transaction-get-date-posted parent)))
-                    " ")))
+                    (gnc:make-html-table-cell/markup
+                     "date-cell"
+                     (gnc-print-date trans-date))
+                    "")))
     
-    (if (used-reconciled-date column-vector)
+    (if (column-uses? 'reconciled-date column-vector)
         (addto! row-contents
-                (gnc:make-html-table-cell/markup "date-cell"
-                                                 (let ((date (gnc-split-get-date-reconciled split)))
-                                                   (if (equal? date (cons 0 0))
-                                                       " "
-                                                       (gnc-print-date date))))))
-    (if (used-num column-vector)
+                (gnc:make-html-table-cell/markup
+                 "date-cell"
+                 (let ((date (gnc-split-get-date-reconciled split)))
+                   (if (equal? date (cons 0 0))
+                       ""
+                       (gnc-print-date date))))))
+
+    (if (column-uses? 'num column-vector)
         (addto! row-contents
                 (if transaction-row?
-                    (if (qof-book-use-split-action-for-num-field
-                         (gnc-get-current-book))
+                    (if (qof-book-use-split-action-for-num-field (gnc-get-current-book))
                         (let* ((num (gnc-get-num-action parent split))
                                (t-num (if (if (gnc:lookup-option options gnc:pagename-display
                                                                  (N_ "Trans Number"))
                                               (opt-val gnc:pagename-display (N_ "Trans Number"))
-                                              #f)
+                                              "")
                                           (gnc-get-num-action parent #f)
                                           ""))
                                (num-string (if (string-null? t-num)
                                                num
                                                (string-append num "/" t-num))))
-                          (gnc:make-html-table-cell/markup "text-cell"
-                                                           num-string))
+                          (gnc:make-html-table-cell/markup "text-cell" num-string))
                         (gnc:make-html-table-cell/markup "text-cell"
                                                          (gnc-get-num-action parent split)))
-                    " ")))
+                    "")))
 
-    (if (used-description column-vector)
+    (if (column-uses? 'description column-vector)
         (addto! row-contents
                 (if transaction-row?
-                    (gnc:make-html-table-cell/markup "text-cell"
-                                                     (xaccTransGetDescription parent))
-                    " ")))
+                    (gnc:make-html-table-cell/markup
+                     "text-cell"
+                     (xaccTransGetDescription parent))
+                    "")))
     
-    (if (used-memo column-vector)
+    (if (column-uses? 'memo column-vector)
         (let ((memo (xaccSplitGetMemo split)))
-          (if (and (equal? memo "") (used-notes column-vector))
+          (if (and (string-null? memo) (column-uses? 'notes column-vector))
               (addto! row-contents (xaccTransGetNotes parent))
               (addto! row-contents memo))))
     
-    (if (or (used-account-name column-vector) (used-account-code column-vector))
+    (if (or (column-uses? 'account-name column-vector) (column-uses? 'account-code column-vector))
         (addto! row-contents (account-namestring account
-                                                 (used-account-code      column-vector)
-                                                 (used-account-name      column-vector)
-                                                 (used-account-full-name column-vector))))
+                                                 (column-uses? 'account-code      column-vector)
+                                                 (column-uses? 'account-name      column-vector)
+                                                 (column-uses? 'account-full-name column-vector))))
     
-    (if (or (used-other-account-name column-vector) (used-other-account-code column-vector))
-        (addto! row-contents (account-namestring (xaccSplitGetAccount
-                                                  (xaccSplitGetOtherSplit split))
-                                                 (used-other-account-code      column-vector)
-                                                 (used-other-account-name      column-vector)
-                                                 (used-other-account-full-name column-vector))))
+    (if (or (column-uses? 'other-account-name column-vector) (column-uses? 'other-account-code column-vector))
+        (addto! row-contents (account-namestring (xaccSplitGetAccount (xaccSplitGetOtherSplit split))
+                                                 (column-uses? 'other-account-code      column-vector)
+                                                 (column-uses? 'other-account-name      column-vector)
+                                                 (column-uses? 'other-account-full-name column-vector))))
     
-    (if (used-shares column-vector)
+    (if (column-uses? 'shares column-vector)
         (addto! row-contents (xaccSplitGetAmount split)))
     
-    (if (used-price column-vector)
-        (addto! row-contents 
-                (gnc:make-gnc-monetary (xaccTransGetCurrency parent)
-                                (xaccSplitGetSharePrice split))))
+    (if (column-uses? 'price column-vector)
+        (addto! row-contents  (gnc:make-gnc-monetary (xaccTransGetCurrency parent)
+                                                     (xaccSplitGetSharePrice split))))
     
-    (if (used-amount-single column-vector)
+    (if (column-uses? 'amount-single column-vector)
         (addto! row-contents
-                (gnc:make-html-table-cell/markup "number-cell"
-                                                 (gnc:html-transaction-anchor parent split-value))))
+                (gnc:make-html-table-cell/markup
+                 "number-cell" (gnc:html-transaction-anchor parent split-value))))
     
-    (if (used-amount-double-positive column-vector)
+    (if (column-uses? 'amount-double column-vector)        
+
         (if (gnc-numeric-positive-p (gnc:gnc-monetary-amount split-value))
-            (addto! row-contents
-                    (gnc:make-html-table-cell/markup "number-cell"
-                                                     (gnc:html-transaction-anchor parent split-value)))
-            (addto! row-contents " ")))
+
+            (begin
+              (addto! row-contents
+                      (gnc:make-html-table-cell/markup
+                       "number-cell" (gnc:html-transaction-anchor
+                                      parent split-value)))
+              (addto! row-contents ""))
+        
+            (begin
+              (addto! row-contents "")
+              (addto! row-contents
+                      (gnc:make-html-table-cell/markup
+                       "number-cell" (gnc:html-transaction-anchor
+                                      parent (gnc:monetary-neg split-value)))))))
     
-    (if (used-amount-double-negative column-vector)
-        (if (gnc-numeric-negative-p (gnc:gnc-monetary-amount split-value))
-            (addto! row-contents
-                    (gnc:make-html-table-cell/markup
-                     "number-cell" (gnc:html-transaction-anchor parent (gnc:monetary-neg split-value))))
-            (addto! row-contents " ")))
-    
-    (if (used-running-balance column-vector)
+    (if (column-uses? 'running-balance column-vector)
         (begin
           ;(gnc:debug "split is " split)
           ;(gnc:debug "split get balance:" (xaccSplitGetBalance split))
@@ -471,7 +459,6 @@ options specified in the Options panels."))
     split-value))
 
 
-(define date-sorting-types (list 'date 'reconciled-date))
 
 
 ;                                                                                                  
@@ -501,23 +488,23 @@ options specified in the Options panels."))
   
   ;; General options
   
-;                                                          
-;                                                          
-;                                                          
-;                                                   ;;;    
-;                                                     ;    
-;        ;                                            ;    
-;    ;;;;;   ;;;;   ; ;;;    ;;;;   ;; ;;;  ;;;;      ;    
-;   ;   ;   ;;  ;   ;;  ;   ;;  ;    ;;  ;      ;     ;    
-;   ;   ;   ;    ;  ;   ;;  ;    ;   ;;         ;     ;    
-;   ;   ;   ;;;;;;  ;   ;;  ;;;;;;   ;;      ;;;;     ;    
-;    ;;;    ;       ;   ;;  ;        ;;     ;   ;     ;    
-;   ;       ;;      ;   ;;  ;;       ;;     ;   ;     ;    
-;    ;;;;    ;;;;;  ;   ;;   ;;;;;  ;;;;     ;;;;;    ;;;; 
-;        ;                                                 
-;   ;    ;                                                 
-;    ;;;;                                                  
-;                                                          
+  ;                                                          
+  ;                                                          
+  ;                                                          
+  ;                                                   ;;;    
+  ;                                                     ;    
+  ;        ;                                            ;    
+  ;    ;;;;;   ;;;;   ; ;;;    ;;;;   ;; ;;;  ;;;;      ;    
+  ;   ;   ;   ;;  ;   ;;  ;   ;;  ;    ;;  ;      ;     ;    
+  ;   ;   ;   ;    ;  ;   ;;  ;    ;   ;;         ;     ;    
+  ;   ;   ;   ;;;;;;  ;   ;;  ;;;;;;   ;;      ;;;;     ;    
+  ;    ;;;    ;       ;   ;;  ;        ;;     ;   ;     ;    
+  ;   ;       ;;      ;   ;;  ;;       ;;     ;   ;     ;    
+  ;    ;;;;    ;;;;;  ;   ;;   ;;;;;  ;;;;     ;;;;;    ;;;; 
+  ;        ;                                                 
+  ;   ;    ;                                                 
+  ;    ;;;;                                                  
+  ;                                                          
 
   (gnc:options-add-date-interval!
    options gnc:pagename-general optname-startdate optname-enddate "a")
@@ -541,23 +528,23 @@ options specified in the Options panels."))
 
   ;; Filtering Options
   
-;                                                                          
-;                                                                          
-;                                                                          
-;      ;;;    ;;    ;;;                               ;;                   
-;     ;       ;;      ;       ;                       ;;                   
-;     ;               ;       ;                                          ; 
-;     ;      ;;;      ;     ;;;;;    ;;;;   ;; ;;;   ;;;    ; ;;;    ;;;;; 
-;   ;;;;;      ;      ;       ;     ;;  ;    ;;  ;     ;    ;;  ;   ;   ;  
-;     ;        ;      ;       ;     ;    ;   ;;        ;    ;   ;;  ;   ;  
-;     ;        ;      ;       ;     ;;;;;;   ;;        ;    ;   ;;  ;   ;  
-;     ;        ;      ;       ;     ;        ;;        ;    ;   ;;   ;;;   
-;     ;        ;      ;       ;     ;;       ;;        ;    ;   ;;  ;      
-;     ;      ;;;;;    ;;;;    ;;;;   ;;;;;  ;;;;     ;;;;;  ;   ;;   ;;;;  
-;                                                                        ; 
-;                                                                   ;    ; 
-;                                                                    ;;;;  
-;                                                                          
+  ;                                                                          
+  ;                                                                          
+  ;                                                                          
+  ;      ;;;    ;;    ;;;                               ;;                   
+  ;     ;       ;;      ;       ;                       ;;                   
+  ;     ;               ;       ;                                          ; 
+  ;     ;      ;;;      ;     ;;;;;    ;;;;   ;; ;;;   ;;;    ; ;;;    ;;;;; 
+  ;   ;;;;;      ;      ;       ;     ;;  ;    ;;  ;     ;    ;;  ;   ;   ;  
+  ;     ;        ;      ;       ;     ;    ;   ;;        ;    ;   ;;  ;   ;  
+  ;     ;        ;      ;       ;     ;;;;;;   ;;        ;    ;   ;;  ;   ;  
+  ;     ;        ;      ;       ;     ;        ;;        ;    ;   ;;   ;;;   
+  ;     ;        ;      ;       ;     ;;       ;;        ;    ;   ;;  ;      
+  ;     ;      ;;;;;    ;;;;    ;;;;   ;;;;;  ;;;;     ;;;;;  ;   ;;   ;;;;  
+  ;                                                                        ; 
+  ;                                                                   ;    ; 
+  ;                                                                    ;;;;  
+  ;                                                                          
 
   (gnc:register-trep-option
    (gnc:make-string-option
@@ -606,23 +593,23 @@ tags within description, notes or memo. ")
 
   ;; Accounts options
   
-;                                                                  
-;                                                                  
-;                                                                  
-;                                                                  
-;                                                     ;            
-;                                                     ;            
-;   ;;;;      ;;;     ;;;    ;;;;   ;   ;;  ; ;;;   ;;;;;    ;;;;  
-;       ;    ;   ;   ;   ;  ;;  ;   ;   ;;  ;;  ;     ;     ;;  ;  
-;       ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;     ;;     
-;    ;;;;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;       ;;;  
-;   ;   ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;         ;  
-;   ;   ;    ;       ;      ;;  ;   ;   ;;  ;   ;;    ;     ;   ;; 
-;    ;;;;;    ;;;;    ;;;;   ;;;;    ;;; ;  ;   ;;    ;;;;   ;;;;  
-;                                                                  
-;                                                                  
-;                                                                  
-;                                                                  
+  ;                                                                  
+  ;                                                                  
+  ;                                                                  
+  ;                                                                  
+  ;                                                     ;            
+  ;                                                     ;            
+  ;   ;;;;      ;;;     ;;;    ;;;;   ;   ;;  ; ;;;   ;;;;;    ;;;;  
+  ;       ;    ;   ;   ;   ;  ;;  ;   ;   ;;  ;;  ;     ;     ;;  ;  
+  ;       ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;     ;;     
+  ;    ;;;;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;       ;;;  
+  ;   ;   ;   ;       ;       ;    ;  ;   ;;  ;   ;;    ;         ;  
+  ;   ;   ;    ;       ;      ;;  ;   ;   ;;  ;   ;;    ;     ;   ;; 
+  ;    ;;;;;    ;;;;    ;;;;   ;;;;    ;;; ;  ;   ;;    ;;;;   ;;;;  
+  ;                                                                  
+  ;                                                                  
+  ;                                                                  
+  ;                                                                  
 
   ;; account to do report on
   (gnc:register-trep-option
@@ -681,23 +668,23 @@ tags within description, notes or memo. ")
 
   ;; Sorting options
   
-;                                                          
-;                                                          
-;                                                          
-;                                     ;;                   
-;                             ;       ;;                   
-;                             ;                          ; 
-;    ;;;;    ;;;;   ;; ;;;  ;;;;;    ;;;    ; ;;;    ;;;;; 
-;   ;;  ;   ;;  ;    ;;  ;    ;        ;    ;;  ;   ;   ;  
-;   ;;      ;    ;   ;;       ;        ;    ;   ;;  ;   ;  
-;     ;;;   ;    ;   ;;       ;        ;    ;   ;;  ;   ;  
-;       ;   ;    ;   ;;       ;        ;    ;   ;;   ;;;   
-;   ;   ;;  ;;  ;    ;;       ;        ;    ;   ;;  ;      
-;    ;;;;    ;;;;   ;;;;      ;;;;   ;;;;;  ;   ;;   ;;;;  
-;                                                        ; 
-;                                                   ;    ; 
-;                                                    ;;;;  
-;                                                          
+  ;                                                          
+  ;                                                          
+  ;                                                          
+  ;                                     ;;                   
+  ;                             ;       ;;                   
+  ;                             ;                          ; 
+  ;    ;;;;    ;;;;   ;; ;;;  ;;;;;    ;;;    ; ;;;    ;;;;; 
+  ;   ;;  ;   ;;  ;    ;;  ;    ;        ;    ;;  ;   ;   ;  
+  ;   ;;      ;    ;   ;;       ;        ;    ;   ;;  ;   ;  
+  ;     ;;;   ;    ;   ;;       ;        ;    ;   ;;  ;   ;  
+  ;       ;   ;    ;   ;;       ;        ;    ;   ;;   ;;;   
+  ;   ;   ;;  ;;  ;    ;;       ;        ;    ;   ;;  ;      
+  ;    ;;;;    ;;;;   ;;;;      ;;;;   ;;;;;  ;   ;;   ;;;;  
+  ;                                                        ; 
+  ;                                                   ;    ; 
+  ;                                                    ;;;;  
+  ;                                                          
 
   (let ((key-choice-list 
          (append
@@ -906,23 +893,23 @@ tags within description, notes or memo. ")
   
   ;; Display options
   
-;                                                          
-;                                                          
-;                                                          
-;       ;;    ;;                    ;;;                    
-;       ;;    ;;                      ;                    
-;       ;;                            ;                    
-;    ;;;;;   ;;;     ;;;;   ; ;;;     ;     ;;;;    ;    ; 
-;   ;;  ;;     ;    ;;  ;   ;;  ;;    ;         ;   ;   ;  
-;   ;   ;;     ;    ;;      ;    ;    ;         ;    ;  ;  
-;   ;   ;;     ;      ;;;   ;    ;    ;      ;;;;    ;  ;  
-;   ;   ;;     ;        ;   ;    ;    ;     ;   ;    ; ;   
-;   ;;  ;;     ;    ;   ;;  ;;  ;     ;     ;   ;     ;;   
-;    ;;;;;   ;;;;;   ;;;;   ; ;;;     ;;;;   ;;;;;    ;;   
-;                           ;                         ;    
-;                           ;                         ;    
-;                           ;                       ;;     
-;                                                          
+  ;                                                          
+  ;                                                          
+  ;                                                          
+  ;       ;;    ;;                    ;;;                    
+  ;       ;;    ;;                      ;                    
+  ;       ;;                            ;                    
+  ;    ;;;;;   ;;;     ;;;;   ; ;;;     ;     ;;;;    ;    ; 
+  ;   ;;  ;;     ;    ;;  ;   ;;  ;;    ;         ;   ;   ;  
+  ;   ;   ;;     ;    ;;      ;    ;    ;         ;    ;  ;  
+  ;   ;   ;;     ;      ;;;   ;    ;    ;      ;;;;    ;  ;  
+  ;   ;   ;;     ;        ;   ;    ;    ;     ;   ;    ; ;   
+  ;   ;;  ;;     ;    ;   ;;  ;;  ;     ;     ;   ;     ;;   
+  ;    ;;;;;   ;;;;;   ;;;;   ; ;;;     ;;;;   ;;;;;    ;;   
+  ;                           ;                         ;    
+  ;                           ;                         ;    
+  ;                           ;                       ;;     
+  ;                                                          
 
   (let ((disp-memo? #t)
         (disp-accname? #t)
@@ -1089,92 +1076,92 @@ Credit Card, and Income accounts."))))))
 
   (define (opt-val section name) (gnc:option-value (gnc:lookup-option options section name)))
 
-  (define (used-date columns-used) (vector-ref columns-used 0))
-  (define (used-reconciled-date columns-used) (vector-ref columns-used 1))
-  (define (used-num columns-used) (vector-ref columns-used 2))
-  (define (used-description columns-used) (vector-ref columns-used 3))
-  (define (used-account-name columns-used) (vector-ref columns-used 4))
-  (define (used-other-account-name columns-used) (vector-ref columns-used 5))	
-  (define (used-shares columns-used) (vector-ref columns-used 6))	
-  (define (used-price columns-used) (vector-ref columns-used 7))	
-  (define (used-amount-single columns-used) (vector-ref columns-used 8))	
-  (define (used-amount-double-positive columns-used) (vector-ref columns-used 9))	
-  (define (used-amount-double-negative columns-used) (vector-ref columns-used 10))	
-  (define (used-running-balance columns-used) (vector-ref columns-used 11))
-  (define (used-account-full-name columns-used) (vector-ref columns-used 12))
-  (define (used-memo columns-used) (vector-ref columns-used 13))
-  (define (used-account-code columns-used) (vector-ref columns-used 14))
-  (define (used-other-account-code columns-used) (vector-ref columns-used 15))
-  (define (used-other-account-full-name columns-used) (vector-ref columns-used 16))
-  (define (used-sort-account-code columns-used) (vector-ref columns-used 17))
-  (define (used-sort-account-full-name columns-used) (vector-ref columns-used 18))
-  (define (used-notes columns-used) (vector-ref columns-used 19))
+;                                                                                  
+;                                                                                  
+;                                                                                  
+;   ;                 ;;    ;;;         ;;                          ;;;            
+;   ;                 ;;      ;         ;;                            ;            
+;   ;                         ;         ;;                            ;            
+;   ; ;;;   ;   ;;   ;;;      ;      ;;;;;            ;;;    ;;;;     ;      ;;;;  
+;   ;;  ;;  ;   ;;     ;      ;     ;;  ;;           ;   ;  ;;  ;     ;     ;;  ;  
+;   ;    ;  ;   ;;     ;      ;     ;   ;;  ;;;;;;  ;       ;    ;    ;     ;;     
+;   ;    ;  ;   ;;     ;      ;     ;   ;;          ;       ;    ;    ;       ;;;  
+;   ;    ;  ;   ;;     ;      ;     ;   ;;          ;       ;    ;    ;         ;  
+;   ;;  ;;  ;   ;;     ;      ;     ;;  ;;           ;      ;;  ;     ;     ;   ;; 
+;   ; ;;;    ;;; ;   ;;;;;    ;;;;   ;;;;;            ;;;;   ;;;;     ;;;;   ;;;;  
+;                                                                                  
+;                                                                                  
+;                                                                                  
+;                                                                                  
 
   (define (build-columns-used)
     (define is-single? (eq? (opt-val gnc:pagename-display optname-detail-level) 'single))
     (define amount-setting (opt-val gnc:pagename-display (N_ "Amount")))
-    (vector
-     (opt-val gnc:pagename-display (N_ "Date"))
-     (opt-val gnc:pagename-display (N_ "Reconciled Date"))
-     (if (gnc:lookup-option options gnc:pagename-display (N_ "Num"))
-         (opt-val gnc:pagename-display (N_ "Num"))
-         (opt-val gnc:pagename-display (N_ "Num/Action")))
-     (opt-val gnc:pagename-display (N_ "Description"))
-     (opt-val gnc:pagename-display (N_ "Account Name"))
-     (and is-single? (opt-val gnc:pagename-display (N_ "Other Account Name")))
-     (opt-val gnc:pagename-display (N_ "Shares"))
-     (opt-val gnc:pagename-display (N_ "Price"))
-     (eq? amount-setting 'single)
-     (eq? amount-setting 'double)
-     (eq? amount-setting 'double)
-     (opt-val gnc:pagename-display (N_ "Running Balance"))
-     (opt-val gnc:pagename-display (N_ "Use Full Account Name"))
-     (opt-val gnc:pagename-display (N_ "Memo"))
-     (opt-val gnc:pagename-display (N_ "Account Code"))
-     (and is-single? (opt-val gnc:pagename-display (N_ "Other Account Code")))
-     (and is-single? (opt-val gnc:pagename-display (N_ "Use Full Other Account Name")))
-     (opt-val pagename-sorting (N_ "Show Account Code"))
-     (opt-val pagename-sorting (N_ "Show Full Account Name"))
-     (opt-val gnc:pagename-display (N_ "Notes"))))
+    (alist->hash-table
+     (list (cons 'date (opt-val gnc:pagename-display (N_ "Date")))
+           (cons 'reconciled-date (opt-val gnc:pagename-display (N_ "Reconciled Date")))
+           (cons 'num (if (gnc:lookup-option options gnc:pagename-display (N_ "Num"))
+                          (opt-val gnc:pagename-display (N_ "Num"))
+                          (opt-val gnc:pagename-display (N_ "Num/Action"))))
+           (cons 'description (opt-val gnc:pagename-display (N_ "Description")))
+           (cons 'account-name (opt-val gnc:pagename-display (N_ "Account Name")))
+           (cons 'other-account-name (and is-single?
+                                          (opt-val gnc:pagename-display (N_ "Other Account Name"))))
+           (cons 'shares (opt-val gnc:pagename-display (N_ "Shares")))
+           (cons 'price (opt-val gnc:pagename-display (N_ "Price")))
+           (cons 'amount-single (eq? amount-setting 'single))
+           (cons 'amount-double (eq? amount-setting 'double))
+           (cons 'running-balance (opt-val gnc:pagename-display (N_ "Running Balance")))
+           (cons 'account-full-name (opt-val gnc:pagename-display (N_ "Use Full Account Name")))
+           (cons 'memo (opt-val gnc:pagename-display (N_ "Memo")))
+           (cons 'account-code (opt-val gnc:pagename-display (N_ "Account Code")))
+           (cons 'other-account-code (and is-single?
+                                          (opt-val gnc:pagename-display (N_ "Other Account Code"))))
+           (cons 'other-account-full-name (and is-single?
+                                               (opt-val gnc:pagename-display (N_ "Use Full Other Account Name"))))
+           (cons 'sort-account-code (opt-val pagename-sorting (N_ "Show Account Code")))
+           (cons 'sort-account-full-name (opt-val pagename-sorting (N_ "Show Full Account Name")))
+           (cons 'notes (opt-val gnc:pagename-display (N_ "Notes"))))))
 
   (define (make-heading-list columns-used)
     (define (add-if pred? item) (if pred? (list item) '()))
     (append
-     (add-if (used-date columns-used)
+     (add-if (column-uses? 'date columns-used)
              (_ "Date"))
-     (add-if (used-reconciled-date columns-used)
+     (add-if (column-uses? 'reconciled-date columns-used)
              (_ "Reconciled Date"))
-     (add-if (used-num columns-used)
+     (add-if (column-uses? 'num columns-used)
              (if (and (qof-book-use-split-action-for-num-field (gnc-get-current-book))
                       (if (gnc:lookup-option options gnc:pagename-display (N_ "Trans Number"))
                           (opt-val gnc:pagename-display (N_ "Trans Number"))
                           #f))
                  (_ "Num/T-Num")
                  (_ "Num")))
-     (add-if (used-description columns-used)
+     (add-if (column-uses? 'description columns-used)
              (_ "Description"))
-     (add-if (used-memo columns-used)
-             (if (used-notes columns-used)
+     (add-if (column-uses? 'memo columns-used)
+             (if (column-uses? 'notes columns-used)
                  (string-append (_ "Memo") "/" (_ "Notes"))
                  (_ "Memo")))
-     (add-if (or (used-account-name columns-used)
-                 (used-account-code columns-used))
+     (add-if (or (column-uses? 'account-name columns-used)
+                 (column-uses? 'account-code columns-used))
              (_ "Account"))
-     (add-if (or (used-other-account-name columns-used)
-                 (used-other-account-code columns-used))
+     (add-if (or (column-uses? 'other-account-name columns-used)
+                 (column-uses? 'other-account-code columns-used))
              (_ "Transfer from/to"))
-     (add-if (used-shares columns-used)
+     (add-if (column-uses? 'shares columns-used)
              (_ "Shares"))
-     (add-if (used-price columns-used)
+     (add-if (column-uses? 'price columns-used)
              (_ "Price"))
-     (add-if (used-amount-single columns-used)
+     (add-if (column-uses? 'amount-single columns-used)
              (_ "Amount"))
      ;; FIXME: Proper labels: what?
-     (add-if (used-amount-double-positive columns-used)
-             (_ "Debit"))
-     (add-if (used-amount-double-negative columns-used)
-             (_ "Credit"))
-     (add-if (used-running-balance columns-used)
+     (if (column-uses? 'amount-double columns-used)
+         (list
+          (_ "Debit")
+          (_ "Credit"))
+         '())
+     (add-if (column-uses? 'running-balance columns-used)
              (_ "Balance"))))
 
   (let ((work-to-do (length splits))
@@ -1418,18 +1405,16 @@ Credit Card, and Income accounts."))))))
           (cons 'register-order (vector
                                  (list QUERY-DEFAULT-SORT)
                                  #f #f #f))
-          (cons 'corresponding-acc-name
-                (vector
-                 (list SPLIT-CORR-ACCT-NAME)
-                 (lambda (a b) (zero? (xaccSplitCompareOtherAccountFullNames a b))) 
-                 render-corresponding-account-subheading
-                 render-corresponding-account-subtotal))
-          (cons 'corresponding-acc-code
-                (vector
-                 (list SPLIT-CORR-ACCT-CODE)
-                 (lambda (a b) (zero? (xaccSplitCompareOtherAccountCodes a b))) 
-                 render-corresponding-account-subheading
-                 render-corresponding-account-subtotal))
+          (cons 'corresponding-acc-name (vector
+                                         (list SPLIT-CORR-ACCT-NAME)
+                                         (lambda (a b) (zero? (xaccSplitCompareOtherAccountFullNames a b))) 
+                                         render-corresponding-account-subheading
+                                         render-corresponding-account-subtotal))
+          (cons 'corresponding-acc-code (vector
+                                         (list SPLIT-CORR-ACCT-CODE)
+                                         (lambda (a b) (zero? (xaccSplitCompareOtherAccountCodes a b))) 
+                                         render-corresponding-account-subheading
+                                         render-corresponding-account-subtotal))
           (cons 'amount        (vector (list SPLIT-VALUE) #f #f #f))
           (cons 'description   (vector (list SPLIT-TRANS TRANS-DESCRIPTION) #f #f #f))
           (if (qof-book-use-split-action-for-num-field (gnc-get-current-book))
@@ -1439,19 +1424,38 @@ Credit Card, and Income accounts."))))))
           (cons 'memo          (vector (list SPLIT-MEMO) #f #f #f))
           (cons 'none          (vector '() #f #f #f))))
 
-  (define date-comp-funcs-assoc-list
-    ;; Extra list for date option. Each entry: (cons
-    ;; 'date-subtotal-option-value (vector subtotal-function
-    ;; subtotal-renderer))
-    (list
-     (cons 'none (vector #f #f #f))
-     (cons 'weekly (vector split-same-week? render-week-subheading render-week-subtotal))
-     (cons 'monthly (vector split-same-month? render-month-subheading render-month-subtotal))
-     (cons 'quarterly (vector split-same-quarter? render-quarter-subheading render-quarter-subtotal))
-     (cons 'yearly (vector split-same-year? render-year-subheading render-year-subtotal))))
-
   (define (get-subtotalstuff-helper name-sortkey name-subtotal name-date-subtotal
-           comp-index date-index)
+                                    comp-index date-index)
+   
+    (define (timepair-year tp)    (gnc:timepair-get-year tp))
+    (define (timepair-quarter tp) (+ (* 10 (timepair-year tp))  (gnc:timepair-get-quarter tp)))
+    (define (timepair-month tp)   (+ (* 100 (timepair-year tp)) (gnc:timepair-get-month tp)))
+    (define (timepair-week tp)    (+ (* 100 (timepair-year tp)) (gnc:timepair-get-week tp)))
+
+    (define (split-same-week? a b)
+      (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
+            (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
+        (= (timepair-week tp-a)
+           (timepair-week tp-b))))
+
+    (define (split-same-month? a b)
+      (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
+            (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
+        (= (timepair-month tp-a)
+           (timepair-month tp-b))))
+
+    (define (split-same-quarter? a b)
+      (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
+            (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
+        (= (timepair-quarter tp-a)
+           (timepair-quarter tp-b))))
+
+    (define (split-same-year? a b)
+      (let ((tp-a (gnc-transaction-get-date-posted (xaccSplitGetParent a)))
+            (tp-b (gnc-transaction-get-date-posted (xaccSplitGetParent b))))
+        (= (timepair-year tp-a)
+           (timepair-year tp-b))))
+    
     ;; The value of the sorting-key multichoice option.
     (let ((sortkey (opt-val pagename-sorting name-sortkey)))
       (if (member sortkey date-sorting-types)
@@ -1460,7 +1464,15 @@ Credit Card, and Income accounts."))))))
           ;; corresponding funcs in the assoc-list.
           (vector-ref
            (cdr (assq (opt-val pagename-sorting name-date-subtotal)
-                      date-comp-funcs-assoc-list)) 
+                      ;; Extra list for date option. Each entry: (cons
+                      ;; 'date-subtotal-option-value (vector subtotal-function
+                      ;; subtotal-renderer))
+                      (list
+                       (cons 'none (vector #f #f #f))
+                       (cons 'weekly (vector split-same-week? render-week-subheading render-week-subtotal))
+                       (cons 'monthly (vector split-same-month? render-month-subheading render-month-subtotal))
+                       (cons 'quarterly (vector split-same-quarter? render-quarter-subheading render-quarter-subtotal))
+                       (cons 'yearly (vector split-same-year? render-year-subheading render-year-subtotal))))) 
            date-index)
           ;; For everything else: 1. check whether sortkey has
           ;; subtotalling enabled at all, 2. check whether the
@@ -1471,7 +1483,7 @@ Credit Card, and Income accounts."))))))
                     (vector-ref (cdr (assq sortkey comp-funcs-assoc-list)) comp-index))))))
   
   (define (get-query-sortkey sort-option-value)
-    (vector-ref  (cdr (assq sort-option-value comp-funcs-assoc-list)) 0))
+    (vector-ref (cdr (assq sort-option-value comp-funcs-assoc-list)) 0))
 
   (define (get-subtotal-pred name-sortkey name-subtotal name-date-subtotal)
     (get-subtotalstuff-helper name-sortkey name-subtotal name-date-subtotal 1 0))
@@ -1546,8 +1558,7 @@ Credit Card, and Income accounts."))))))
             ;; error condition: no accounts specified
             (gnc:html-document-add-object!
              document 
-             (gnc:html-make-no-account-warning 
-              report-title (gnc:report-id report-obj)))
+             (gnc:html-make-no-account-warning report-title (gnc:report-id report-obj)))
 
             ;; error condition: accounts were specified but none matcher string/regex
             (gnc:html-document-add-object!
@@ -1638,9 +1649,9 @@ Credit Card, and Income accounts."))))))
                  (gnc:make-html-text
                   (gnc:html-markup-h3 
                    (sprintf #f
-                           (_ "From %s to %s")
-                           (gnc-print-date begindate)
-                           (gnc-print-date enddate)))))
+                            (_ "From %s to %s")
+                            (gnc-print-date begindate)
+                            (gnc-print-date enddate)))))
 
                 (gnc:html-document-add-object! document table)))))
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -978,7 +978,7 @@ Credit Card, and Income accounts."))))))
     ;
 
     ;; display an account name depending on the options the user has set
-    (define (account-namestring account code? name? full-name?)
+    (define (account-namestring account show-account-code? show-account-name? show-account-full-name?)
       ;;# on multi-line splits we can get an empty ('()) account
       (if (null? account)
           (_ "Split Transaction")
@@ -1015,8 +1015,9 @@ Credit Card, and Income accounts."))))))
                               "")))
         (if (and anchor? (not (null? account))) ;html anchor for 2-split transactions only
             (gnc:make-html-text
-             (gnc:html-markup-anchor (gnc:account-anchor-text account) name))
-            (string-append name description))))
+             (gnc:html-markup-anchor (gnc:account-anchor-text account) name)
+             description)
+            name)))
 
     (define (render-summary split renderer-key anchor?)
       (case renderer-key

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -135,92 +135,92 @@ options specified in the Options panels."))
   ;;  'split-sortvalue     - function which retrieves number/string used for comparing splits
   ;;  'text                - text displayed in Display tab
   ;;  'tip                 - tooltip displayed in Display tab
-  ;;  'renderer            - helper symbol to select subtotal/subheading renderer
+  ;;  'renderer-key        - helper symbol to select subtotal/subheading renderer
   ;;
   (list (cons 'account-name  (list (cons 'sortkey (list SPLIT-ACCT-FULLNAME))
                                    (cons 'split-sortvalue (lambda (a) (gnc-account-get-full-name (xaccSplitGetAccount a))))
                                    (cons 'text (N_ "Account Name"))
                                    (cons 'tip (N_ "Sort & subtotal by account name."))
-                                   (cons 'renderer 'account)))
+                                   (cons 'renderer-key 'account)))
         
         (cons 'account-code (list (cons 'sortkey (list SPLIT-ACCOUNT ACCOUNT-CODE-))
                                   (cons 'split-sortvalue (lambda (a) (xaccAccountGetCode (xaccSplitGetAccount a))))
                                   (cons 'text (N_ "Account Code"))
                                   (cons 'tip (N_ "Sort & subtotal by account code."))
-                                  (cons 'renderer 'account)))
+                                  (cons 'renderer-key 'account)))
 
         (cons 'date         (list (cons 'sortkey (list SPLIT-TRANS TRANS-DATE-POSTED))
                                   (cons 'split-sortvalue #f)
                                   (cons 'text (N_ "Date"))
                                   (cons 'tip (N_ "Sort by date."))
-                                  (cons 'renderer #f)))
+                                  (cons 'renderer-key #f)))
 
         (cons 'reconciled-date (list (cons 'sortkey (list SPLIT-DATE-RECONCILED))
                                      (cons 'split-sortvalue #f)
                                      (cons 'text (N_ "Reconciled Date"))
                                      (cons 'tip (N_ "Sort by the Reconciled Date."))
-                                     (cons 'renderer #f)))
+                                     (cons 'renderer-key #f)))
 
         (cons 'register-order (list (cons 'sortkey (list QUERY-DEFAULT-SORT))
                                     (cons 'split-sortvalue #f)
                                     (cons 'text (N_ "Register Order"))
                                     (cons 'tip (N_ "Sort as in the register."))
-                                    (cons 'renderer #f)))                                 
+                                    (cons 'renderer-key #f)))                                 
 
         (cons 'corresponding-acc-name (list (cons 'sortkey (list SPLIT-CORR-ACCT-NAME))
                                             (cons 'split-sortvalue (lambda (a) (xaccSplitGetCorrAccountFullName a)))
                                             (cons 'text (N_ "Other Account Name"))
                                             (cons 'tip (N_ "Sort by account transferred from/to's name."))
-                                            (cons 'renderer 'other-acc)))
+                                            (cons 'renderer-key 'other-acc)))
 
         (cons 'corresponding-acc-code (list (cons 'sortkey (list SPLIT-CORR-ACCT-CODE))
                                             (cons 'split-sortvalue (lambda (a) (xaccSplitGetCorrAccountCode a)))
                                             (cons 'text (N_ "Other Account Code"))
                                             (cons 'tip (N_ "Sort by account transferred from/to's code."))
-                                            (cons 'renderer 'other-acct)))
+                                            (cons 'renderer-key 'other-acct)))
 
         (cons 'amount        (list (cons 'sortkey (list SPLIT-VALUE))
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "Amount."))
                                    (cons 'tip (N_ "Sort by amount."))
-                                   (cons 'renderer #f)))
+                                   (cons 'renderer-key #f)))
 
         (cons 'description   (list (cons 'sortkey (list SPLIT-TRANS TRANS-DESCRIPTION))
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "Description"))
                                    (cons 'tip (N_ "Sort by description."))
-                                   (cons 'renderer #f)))
+                                   (cons 'renderer-key #f)))
 
         (if BOOK-SPLIT-ACTION
             (cons 'number    (list (cons 'sortkey (list SPLIT-ACTION))
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "Number/Action"))
                                    (cons 'tip (N_ "Sort by check number/action."))
-                                   (cons 'renderer #f)))
+                                   (cons 'renderer-key #f)))
 
             (cons 'number    (list (cons 'sortkey (list SPLIT-TRANS TRANS-NUM))
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "Number"))
                                    (cons 'tip (N_ "Sort by check/transaction number."))
-                                   (cons 'renderer #f))))
+                                   (cons 'renderer-key #f))))
 
         (cons 't-number      (list (cons 'sortkey (list SPLIT-TRANS TRANS-NUM))
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "Transaction Number"))
                                    (cons 'tip (N_ "Sort by transaction number."))
-                                   (cons 'renderer #f)))
+                                   (cons 'renderer-key #f)))
 
         (cons 'memo          (list (cons 'sortkey (list SPLIT-MEMO))
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "Memo"))
                                    (cons 'tip (N_ "Sort by memo."))
-                                   (cons 'renderer #f)))
+                                   (cons 'renderer-key #f)))
 
         (cons 'none          (list (cons 'sortkey '())
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (N_ "None"))
                                    (cons 'tip (N_ "Do not sort."))
-                                   (cons 'renderer #f)))))
+                                   (cons 'renderer-key #f)))))
 
 
 (define (sortkey-get-info sortkey info)
@@ -236,39 +236,42 @@ options specified in the Options panels."))
 (define (split-year a) (timepair-year (gnc-transaction-get-date-posted (xaccSplitGetParent a))))
 
 (define date-subtotal-list
-  ;; Extra list for date option. Each entry: (cons
-  ;; 'date-subtotal-option-value (vector subtotal-function
-  ;; subtotal-renderer))
+  ;; List for date option. 
+  ;; Defines the different date sorting keys, as an association-list. Each entry: 
+  ;;  'split-sortvalue     - function which retrieves number/string used for comparing splits
+  ;;  'text                - text displayed in Display tab
+  ;;  'tip                 - tooltip displayed in Display tab
+  ;;  'renderer-key        - helper symbol to select subtotal/subheading renderer
   (list
    (cons 'none (list
                 (cons 'split-sortvalue #f)
                 (cons 'text (N_ "None"))
                 (cons 'tip (N_ "None."))
-                (cons 'renderer #f)))
+                (cons 'renderer-key #f)))
 
    (cons 'weekly (list
                   (cons 'split-sortvalue split-week)
                   (cons 'text (N_ "Weekly"))
                   (cons 'tip (N_ "Weekly."))
-                  (cons 'renderer 'week)))
+                  (cons 'renderer-key 'week)))
 
    (cons 'monthly (list
                    (cons 'split-sortvalue split-month)
                    (cons 'text (N_ "Monthly"))
                    (cons 'tip (N_ "Monthly."))
-                   (cons 'renderer 'month)))
+                   (cons 'renderer-key 'month)))
 
    (cons 'quarterly (list
                      (cons 'split-sortvalue split-quarter)
                      (cons 'text (N_ "Quarterly"))
                      (cons 'tip (N_ "Quarterly."))
-                     (cons 'renderer 'quarter)))
+                     (cons 'renderer-key 'quarter)))
 
    (cons 'yearly (list
                   (cons 'split-sortvalue split-year)
                   (cons 'text (N_ "Yearly"))
                   (cons 'tip (N_ "Yearly."))
-                  (cons 'renderer 'year)))))
+                  (cons 'renderer-key 'year)))))
 
 (define (date-subtotal-get-info sortkey info)
   (cdr (assq info (cdr (assq sortkey date-subtotal-list)))))
@@ -816,10 +819,10 @@ Credit Card, and Income accounts."))))))
 ;                                                                                                                                  
 
 (define (make-split-table splits options
-                          primary-subtotal-pred
-                          secondary-subtotal-pred
-                          primary-sortkey
-                          secondary-sortkey)
+                          primary-subtotal-comparator
+                          secondary-subtotal-comparator
+                          primary-renderer-key
+                          secondary-renderer-key)
 
   (define (opt-val section name) (gnc:option-value (gnc:lookup-option options section name)))
 
@@ -889,8 +892,8 @@ Credit Card, and Income accounts."))))))
      ;; FIXME: Proper labels: what?
      ;; formerly Debit/Credit, but not always true; change to Positive/Negative for now
      (add-if (column-uses? 'amount-double columns-used)
-             (_ "Positive")
-             (_ "Negative"))
+             (_ "Debit")
+             (_ "Credit"))
      (add-if (column-uses? 'running-balance columns-used)
              (_ "Balance"))))
 
@@ -966,116 +969,46 @@ Credit Card, and Income accounts."))))))
       (if (null? account)
           (_ "Split Transaction")
           (string-append 
-           ;; display account code?
            (if show-account-code?
                (string-append (xaccAccountGetCode account) " ")
                "")
-           ;; display account name?
            (if show-account-name?
-               ;; display full account name?
                (if show-account-full-name?
                    (gnc-account-get-full-name account)
                    (xaccAccountGetName account))
                ""))))
 
-    ;; render an account subheading - used-columns determines what is displayed
-    (define (render-account-subheading split)
-      (let ((account (xaccSplitGetAccount split)))
-        (gnc:make-html-text
-         (gnc:html-markup-anchor
-          (gnc:account-anchor-text account)
-          (account-namestring account
-                              (column-uses? 'sort-account-code      used-columns)
-                              #t
-                              (column-uses? 'sort-account-full-name used-columns))))))                        
-
-    (define (render-corresponding-account-subheading split)
-      (let ((account (xaccSplitGetAccount (xaccSplitGetOtherSplit split))))
-        (gnc:make-html-text
-         (gnc:html-markup-anchor
-          (if (null? account)
-              ""
-              (gnc:account-anchor-text account))
-          (account-namestring account
-                              (column-uses? 'sort-account-code      used-columns)
-                              #t
-                              (column-uses? 'sort-account-full-name used-columns))))))
-
-    (define (render-week-subheading split)
-      (gnc:date-get-week-year-string
+    (define (render-date renderer-key split)      
+      ((case renderer-key
+         ((week) gnc:date-get-week-year-string)
+         ((month) gnc:date-get-month-year-string)
+         ((quarter) gnc:date-get-quarter-year-string)
+         ((year) gnc:date-get-year-string))
        (gnc:timepair->date
         (gnc-transaction-get-date-posted
          (xaccSplitGetParent split)))))
-  
-    (define (render-month-subheading split)
-      (gnc:date-get-month-year-string
-       (gnc:timepair->date 
-        (gnc-transaction-get-date-posted
-         (xaccSplitGetParent split)))))
-  
-    (define (render-quarter-subheading split)
-      (gnc:date-get-quarter-year-string 
-       (gnc:timepair->date 
-        (gnc-transaction-get-date-posted
-         (xaccSplitGetParent split)))))
 
-
-    (define (render-year-subheading split)
-      (gnc:date-get-year-string 
-       (gnc:timepair->date 
-        (gnc-transaction-get-date-posted
-         (xaccSplitGetParent split)))))
-
-    (define (render-account-subtotal split)
-      (account-namestring (xaccSplitGetAccount split)
-                          (column-uses? 'sort-account-code      used-columns)
-                          #t
-                          (column-uses? 'sort-account-full-name used-columns)))
-
-    (define (render-corresponding-account-subtotal split)
-      (account-namestring (xaccSplitGetAccount (xaccSplitGetOtherSplit split))
-                          (column-uses? 'sort-account-code      used-columns)
-                          #t
-                          (column-uses? 'sort-account-full-name used-columns)))
-
-    (define (render-week-subtotal split)
-      (let ((tm (gnc:timepair->date (gnc-transaction-get-date-posted (xaccSplitGetParent split)))))
-        (gnc:date-get-week-year-string tm)))
-
-    (define (render-month-subtotal split)
-      (let ((tm (gnc:timepair->date (gnc-transaction-get-date-posted (xaccSplitGetParent split)))))
-        (gnc:date-get-month-year-string tm)))
-
-    (define (render-quarter-subtotal split)
-      (let ((tm (gnc:timepair->date (gnc-transaction-get-date-posted (xaccSplitGetParent split)))))
-        (gnc:date-get-quarter-year-string tm)))
-
-    (define (render-year-subtotal split)
-      (let ((tm (gnc:timepair->date (gnc-transaction-get-date-posted (xaccSplitGetParent split)))))
-        (strftime "%Y" tm)))
+    (define (render-account renderer-key split anchor?)
+      (let* ((account (case renderer-key
+                        ((account) (xaccSplitGetAccount split))
+                        ((other-acc) (xaccSplitGetAccount (xaccSplitGetOtherSplit split)))))
+             (name (account-namestring account
+                                       (column-uses? 'sort-account-code      used-columns)
+                                       #t
+                                       (column-uses? 'sort-account-full-name used-columns))))
+        (if (and anchor? (not (null? account))) ;html anchor for 2-split transactions only
+            (gnc:make-html-text
+             (gnc:html-markup-anchor (gnc:account-anchor-text account) name))
+            name)))
+    
+    (define (render-summary split renderer-key anchor?)
+      (case renderer-key
+        ((week month quarter year) (render-date renderer-key split))
+        ((account other-acc) (render-account renderer-key split anchor?))
+        (else #f)))
 
     (define (render-grand-total)
       (_ "Grand Total"))
-    
-    (define (subheading-renderer split key)
-      ((case key
-         ((week)      render-week-subheading)
-         ((month)     render-month-subheading)
-         ((quarter)   render-quarter-subheading)
-         ((year)      render-year-subheading)
-         ((account)   render-account-subheading)
-         ((other-acc) render-corresponding-account-subheading))
-       split))
-    
-    (define (subtotal-renderer split key)
-      ((case key
-         ((week)      render-week-subtotal)
-         ((month)     render-month-subtotal)
-         ((quarter)   render-quarter-subtotal)
-         ((year)      render-year-subtotal)
-         ((account)   render-account-subtotal)
-         ((other-acc) render-corresponding-account-subtotal))
-       split))
     
     ;
     ;                                                                                                          
@@ -1097,7 +1030,6 @@ Credit Card, and Income accounts."))))))
     ;                                                                                                          
 
     (define (add-split-row split row-style transaction-row?)
-
       (let* ((row-contents '())
              (parent (xaccSplitGetParent split))
              (account (xaccSplitGetAccount split))
@@ -1112,6 +1044,10 @@ Credit Card, and Income accounts."))))))
                           (xaccSplitVoidFormerAmount split)
                           (xaccSplitGetAmount split)))
              (trans-date (gnc-transaction-get-date-posted parent))
+             (split-value-not-reversed (gnc:exchange-by-pricedb-nearest ; used for correct debit/credit
+                                        (gnc:make-gnc-monetary currency damount)
+                                        report-currency
+                                        (timespecCanonicalDayTime trans-date)))
              (split-value (gnc:exchange-by-pricedb-nearest
                            (gnc:make-gnc-monetary 
                             currency
@@ -1123,7 +1059,7 @@ Credit Card, and Income accounts."))))))
                            ;; on the same day.  Otherwise it uses midnight which will
                            ;; likely match a price on the previous day
                            (timespecCanonicalDayTime trans-date))))
-    
+        
         (if (column-uses? 'date used-columns)
             (addto! row-contents
                     (if transaction-row?
@@ -1198,23 +1134,24 @@ Credit Card, and Income accounts."))))))
                     (gnc:make-html-table-cell/markup
                      "number-cell" (gnc:html-transaction-anchor parent split-value))))
     
-        (if (column-uses? 'amount-double used-columns)        
-
-            (if (gnc-numeric-positive-p (gnc:gnc-monetary-amount split-value))
-
+        (if (column-uses? 'amount-double used-columns)
+            ;; I'm now using the split-value-not-reversed. Internal value representation
+            ;; is positive = debit amount
+            ;; is negative = credit amount
+            ;; This must be checked. FIXME.
+            (if (gnc-numeric-positive-p (gnc:gnc-monetary-amount split-value-not-reversed))
                 (begin
                   (addto! row-contents
                           (gnc:make-html-table-cell/markup
                            "number-cell" (gnc:html-transaction-anchor
-                                          parent split-value)))
+                                          parent split-value-not-reversed)))
                   (addto! row-contents ""))
-        
                 (begin
                   (addto! row-contents "")
                   (addto! row-contents
                           (gnc:make-html-table-cell/markup
                            "number-cell" (gnc:html-transaction-anchor
-                                          parent (gnc:monetary-neg split-value)))))))
+                                          parent (gnc:monetary-neg split-value-not-reversed)))))))
     
         (if (column-uses? 'running-balance used-columns)
             (begin
@@ -1298,45 +1235,45 @@ Credit Card, and Income accounts."))))))
             (total-collector
              'add (gnc:gnc-monetary-commodity split-value) (gnc:gnc-monetary-amount split-value))
             
-            (if (and primary-subtotal-pred
+            (if (and primary-subtotal-comparator
                      (or (not next)
                          (and next
-                              (not (equal? (primary-subtotal-pred current)
-                                           (primary-subtotal-pred next))))))
+                              (not (equal? (primary-subtotal-comparator current)
+                                           (primary-subtotal-comparator next))))))
                 
                 (begin                   
-                  (if secondary-subtotal-pred                      
+                  (if secondary-subtotal-comparator                      
                       (begin                        
                         (add-subtotal-row (total-string
-                                           (subtotal-renderer current secondary-sortkey))
+                                           (render-summary current secondary-renderer-key #f))
                                            secondary-subtotal-collector
                                            def:secondary-subtotal-style)
                         (secondary-subtotal-collector 'reset #f #f)))                  
                   (add-subtotal-row (total-string
-                                     (subtotal-renderer current primary-sortkey))
+                                     (render-summary current primary-renderer-key #f))
                                      primary-subtotal-collector
                                      def:primary-subtotal-style)                  
                   (primary-subtotal-collector 'reset #f #f)                  
                   (if next                      
                       (begin                         
-                        (add-subheading (subheading-renderer next primary-sortkey)
+                        (add-subheading (render-summary next primary-renderer-key #t)
                                         def:primary-subtotal-style)                        
-                        (if secondary-subtotal-pred
-                            (add-subheading (subheading-renderer next secondary-sortkey)
+                        (if secondary-subtotal-comparator
+                            (add-subheading (render-summary next secondary-renderer-key #t)
                                             def:secondary-subtotal-style)))))
                 
-                (if (and secondary-subtotal-pred
+                (if (and secondary-subtotal-comparator
                          (or (not next)
                              (and next
-                                  (not (equal? (secondary-subtotal-pred current)
-                                               (secondary-subtotal-pred next))))))
+                                  (not (equal? (secondary-subtotal-comparator current)
+                                               (secondary-subtotal-comparator next))))))
                     (begin (add-subtotal-row (total-string
-                                              (subtotal-renderer current secondary-sortkey))
+                                              (render-summary current secondary-renderer-key #f))
                                               secondary-subtotal-collector
                                              def:secondary-subtotal-style)                           
                            (secondary-subtotal-collector 'reset #f #f)                           
                            (if next
-                               (add-subheading (subheading-renderer next secondary-sortkey)
+                               (add-subheading (render-summary next secondary-renderer-key #t)
                                                def:secondary-subtotal-style)))))
             
             (do-rows-with-subtotals rest 
@@ -1347,12 +1284,12 @@ Credit Card, and Income accounts."))))))
     
     (gnc:html-table-set-col-headers! table headings)
     
-    (if primary-sortkey 
-        (add-subheading (subheading-renderer (car splits) primary-sortkey)
+    (if primary-renderer-key 
+        (add-subheading (render-summary (car splits) primary-renderer-key #t)
                         def:primary-subtotal-style))
     
-    (if secondary-sortkey
-        (add-subheading (subheading-renderer (car splits) secondary-sortkey)
+    (if secondary-renderer-key
+        (add-subheading (render-summary (car splits) secondary-renderer-key #t)
                         def:secondary-subtotal-style))
     
     (do-rows-with-subtotals splits #t
@@ -1543,12 +1480,11 @@ Credit Card, and Income accounts."))))))
                             (subtotal-get-info optname-prime-sortkey 
                                                optname-prime-subtotal
                                                optname-prime-date-subtotal
-                                               'renderer)
+                                               'renderer-key)
                             (subtotal-get-info optname-sec-sortkey 
                                                optname-sec-subtotal
                                                optname-sec-date-subtotal
-                                               'renderer)
-                            )))
+                                               'renderer-key))))
                 
                 (gnc:html-document-set-title! document report-title)
 


### PR DESCRIPTION
Just wished to store some discussion about future-proofing transaction.scm

If there will be some datafile forward-compatible upgrades, wouldn't it be worthwhile to implement a skeleton for future improvements and remove dead code?

1. remove 'exact-time as sorting option - this is exactly same sorting strategy as 'date
2. move transaction matcher to 'filtering' tab - this is in preparation for further filtering capabilities as per demand e.g. filter by reconcile status, invoices paid/outstanding. Maybe also move the Account Filter into this tab?

Future ideas:
1. also remove sorting option 'reconciled-date - is this ever useful?
2. perhaps an optional text can be output into the report to summarise filters being used
   "Filters applied: Transaction Matcher '#work'"
3. I'm thinking of upgrading the subtotal methods to enable accounts parents' subtotals but this is proving to be a headache. (e.g. subtotal on Expenses:Business:Marketing will also subtotal Expenses:Business).

See screenshot, and commit.
![image](https://user-images.githubusercontent.com/1975870/32150893-eb6b9506-bd52-11e7-88b7-23c488091ad6.png)
